### PR TITLE
Move README.md into rust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@
 [![docs.rs](https://docs.rs/oci-spec/badge.svg)](https://docs.rs/oci-spec)
 [![dependencies](https://deps.rs/repo/github/containers/oci-spec-rs/status.svg)](https://deps.rs/repo/github/containers/oci-spec-rs)
 [![license](https://img.shields.io/github/license/containers/oci-spec-rs.svg)](https://github.com/containers/oci-spec-rs/blob/master/LICENSE)
+
+### Open Container Initiative (OCI) Specifications for Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs, warnings)]
-
-//! Open Container Initiative (OCI) Specifications for Rust.
+#![doc = include_str!("../README.md")]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This allows us to reduce duplication by providing the same docs in both
files.
