### PR TITLE
Remove cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,12 @@ image = []
 runtime = []
 
 [dependencies]
-serde = { version = "1.0.128", features = ["derive"] }
+serde = { version = "1.0.129", features = ["derive"] }
 thiserror = "1.0.26"
 serde_json = "1.0.66"
 quickcheck = { version = "1.0.3", optional = true }
 derive_builder = { version = "0.10.2", optional = true }
 getset = { version = "0.1.1", optional = true }
-cfg-if = "1.0.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -200,18 +200,31 @@ impl Spec {
         Ok(())
     }
 
+    #[cfg(not(feature = "builder"))]
     /// Canonicalize the `root.path` of the `Spec` for the provided `bundle`.
     pub fn canonicalize_rootfs<P: AsRef<Path>>(&mut self, bundle: P) -> Result<()> {
-        cfg_if::cfg_if!(
-            if #[cfg(feature = "builder")] {
-                let root = self.root.as_ref().ok_or_else(||oci_error("no root path provided for canonicalization"))?;
-                let path = Self::canonicalize_path(bundle, root.path())?;
-                self.root = Some(RootBuilder::default().path(path).readonly(root.readonly()).build()
-                .map_err(|_| oci_error("failed to set canonicalized root"))?);
-            } else {
-                let root = self.root.as_mut().ok_or_else(||oci_error("no root path provided for canonicalization"))?;
-                root.path = Self::canonicalize_path(bundle, &root.path)?;
-            }
+        let root = self
+            .root
+            .as_mut()
+            .ok_or_else(|| oci_error("no root path provided for canonicalization"))?;
+        root.path = Self::canonicalize_path(bundle, &root.path)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "builder")]
+    /// Canonicalize the `root.path` of the `Spec` for the provided `bundle`.
+    pub fn canonicalize_rootfs<P: AsRef<Path>>(&mut self, bundle: P) -> Result<()> {
+        let root = self
+            .root
+            .as_ref()
+            .ok_or_else(|| oci_error("no root path provided for canonicalization"))?;
+        let path = Self::canonicalize_path(bundle, root.path())?;
+        self.root = Some(
+            RootBuilder::default()
+                .path(path)
+                .readonly(root.readonly())
+                .build()
+                .map_err(|_| oci_error("failed to set canonicalized root"))?,
         );
         Ok(())
     }
@@ -235,6 +248,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "builder")]
     fn test_canonicalize_rootfs() {
         let rootfs_name = "rootfs";
         let bundle = tempfile::tempdir().expect("failed to create tmp test bundle dir");
@@ -246,79 +260,88 @@ mod tests {
         fs::create_dir_all(&rootfs_absolute_path).expect("failed to create the testing rootfs");
         {
             // Test the case with absolute path
-            cfg_if::cfg_if!(
-                if #[cfg(feature = "builder")] {
-                    let mut spec = SpecBuilder::default()
-                        .root(RootBuilder::default()
-                            .path(rootfs_absolute_path.clone())
-                            .build().unwrap())
-                        .build().unwrap();
-                } else {
-                    let mut spec = Spec {
-                        root: Root {
-                            path: rootfs_absolute_path.clone(),
-                            ..Default::default()
-                        }
-                        .into(),
-                        ..Default::default()
-                    };
-                }
-            );
+            let mut spec = SpecBuilder::default()
+                .root(
+                    RootBuilder::default()
+                        .path(rootfs_absolute_path.clone())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap();
 
             spec.canonicalize_rootfs(bundle.path())
                 .expect("failed to canonicalize rootfs");
 
-            cfg_if::cfg_if!(
-                if #[cfg(feature = "builder")] {
-                    assert_eq!(
-                        &rootfs_absolute_path,
-                        spec.root.expect("no root in spec").path()
-                    );
-                } else {
-                    assert_eq!(
-                        rootfs_absolute_path,
-                        spec.root.expect("no root in spec").path
-                    );
-                }
+            assert_eq!(
+                &rootfs_absolute_path,
+                spec.root.expect("no root in spec").path()
             );
         }
-
         {
             // Test the case with relative path
-            cfg_if::cfg_if!(
-                if #[cfg(feature = "builder")] {
-                    let mut spec = SpecBuilder::default()
-                        .root(RootBuilder::default()
-                            .path(rootfs_name)
-                            .build().unwrap())
-                        .build().unwrap();
-                } else {
-                    let mut spec = Spec {
-                        root: Root {
-                            path: PathBuf::from(rootfs_name),
-                            ..Default::default()
-                        }
-                        .into(),
-                        ..Default::default()
-                    };
-                }
-            );
+            let mut spec = SpecBuilder::default()
+                .root(RootBuilder::default().path(rootfs_name).build().unwrap())
+                .build()
+                .unwrap();
 
             spec.canonicalize_rootfs(bundle.path())
                 .expect("failed to canonicalize rootfs");
 
-            cfg_if::cfg_if!(
-                if #[cfg(feature = "builder")] {
-                    assert_eq!(
-                        &rootfs_absolute_path,
-                        spec.root.expect("no root in spec").path()
-                    );
-                } else {
-                    assert_eq!(
-                        rootfs_absolute_path,
-                        spec.root.expect("no root in spec").path
-                    );
+            assert_eq!(
+                &rootfs_absolute_path,
+                spec.root.expect("no root in spec").path()
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "builder"))]
+    fn test_canonicalize_rootfs() {
+        let rootfs_name = "rootfs";
+        let bundle = tempfile::tempdir().expect("failed to create tmp test bundle dir");
+        let rootfs_absolute_path = bundle.path().join(rootfs_name);
+        assert!(
+            rootfs_absolute_path.is_absolute(),
+            "rootfs path is not absolute path"
+        );
+        fs::create_dir_all(&rootfs_absolute_path).expect("failed to create the testing rootfs");
+        {
+            // Test the case with absolute path
+            let mut spec = Spec {
+                root: Root {
+                    path: rootfs_absolute_path.clone(),
+                    ..Default::default()
                 }
+                .into(),
+                ..Default::default()
+            };
+
+            spec.canonicalize_rootfs(bundle.path())
+                .expect("failed to canonicalize rootfs");
+
+            assert_eq!(
+                rootfs_absolute_path,
+                spec.root.expect("no root in spec").path
+            );
+        }
+        {
+            // Test the case with relative path
+            let mut spec = Spec {
+                root: Root {
+                    path: PathBuf::from(rootfs_name),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            };
+
+            spec.canonicalize_rootfs(bundle.path())
+                .expect("failed to canonicalize rootfs");
+
+            assert_eq!(
+                rootfs_absolute_path,
+                spec.root.expect("no root in spec").path
             );
         }
     }

--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -10,44 +10,45 @@ fn serialize_and_deserialize_spec() {
 }
 
 #[test]
+#[cfg(feature = "builder")]
 fn test_linux_device_cgroup_to_string() {
-    cfg_if::cfg_if!(
-        if #[cfg(feature = "builder")] {
-            let ldc = LinuxDeviceCgroupBuilder::default().
-                allow(true).
-                typ(LinuxDeviceType::B).
-                access("rwm".to_string()).
-                build().expect("build device cgroup");
-        } else {
-            let ldc = LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::B),
-                major: None,
-                minor: None,
-                access: Some("rwm".into()),
-            };
-        }
-    );
+    let ldc = LinuxDeviceCgroupBuilder::default()
+        .allow(true)
+        .typ(LinuxDeviceType::B)
+        .access("rwm".to_string())
+        .build()
+        .expect("build device cgroup");
     assert_eq!(ldc.to_string(), "b *:* rwm");
 
-    cfg_if::cfg_if!(
-        if #[cfg(feature = "builder")] {
-            let ldc = LinuxDeviceCgroupBuilder::default()
-                .allow(true)
-                .typ(LinuxDeviceType::B)
-                .major(1)
-                .minor(9)
-                .access("rwm".to_string())
-                .build().expect("build device cgroup");
-        } else {
-            let ldc = LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::B),
-                major: Some(1),
-                minor: Some(9),
-                access: Some("rwm".into()),
-            };
-        }
-    );
+    let ldc = LinuxDeviceCgroupBuilder::default()
+        .allow(true)
+        .typ(LinuxDeviceType::B)
+        .major(1)
+        .minor(9)
+        .access("rwm".to_string())
+        .build()
+        .expect("build device cgroup");
+    assert_eq!(ldc.to_string(), "b 1:9 rwm");
+}
+
+#[test]
+#[cfg(not(feature = "builder"))]
+fn test_linux_device_cgroup_to_string() {
+    let ldc = LinuxDeviceCgroup {
+        allow: true,
+        typ: Some(LinuxDeviceType::B),
+        major: None,
+        minor: None,
+        access: Some("rwm".into()),
+    };
+    assert_eq!(ldc.to_string(), "b *:* rwm");
+
+    let ldc = LinuxDeviceCgroup {
+        allow: true,
+        typ: Some(LinuxDeviceType::B),
+        major: Some(1),
+        minor: Some(9),
+        access: Some("rwm".into()),
+    };
     assert_eq!(ldc.to_string(), "b 1:9 rwm");
 }


### PR DESCRIPTION
We now get rid of this additional dependency by using `cfg` attributes.
