### PR TITLE
Derive serde traits for Reference

### DIFF
--- a/src/distribution/reference.rs
+++ b/src/distribution/reference.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::{convert::TryFrom, sync::OnceLock};
 
 use regex::{Regex, RegexBuilder};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// NAME_TOTAL_LENGTH_MAX is the maximum total number of characters in a repository name.
@@ -72,12 +73,15 @@ pub enum ParseError {
 /// assert_eq!(Some("latest"), reference.tag());
 /// assert_eq!(None, reference.digest());
 /// ```
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Reference {
     registry: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mirror_registry: Option<String>,
     repository: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     digest: Option<String>,
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
-->
/kind feature
<!--
/kind flake
/kind other
-->

#### What this PR does / why we need it:

Adds `Serialize` and `Deserialize` support for the `Reference` type recently imported from `oci_distribution`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added serde `Serialize`/`Deserialize` support for `distribution::Reference`
```
