### PR TITLE
Change Arch repr to u32 instead of isize to support wasm32 targets

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1096,10 +1096,10 @@ impl Default for LinuxSeccompAction {
     }
 }
 
-#[allow(clippy::enum_clike_unportable_variant)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, StrumDisplay, EnumString)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[repr(u32)]
 /// Available seccomp architectures.
 pub enum Arch {
     /// The native architecture.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR removes the clippy unportable warning and changes the internal representation of Arch from a isize to a u32. This makes the type portable across other architecture (e.g. WASM32). See the following example:

```
cargo build --target wasm32-unknown-unknown
   Compiling oci-spec v0.7.1
error: literal out of range for `isize`
    --> src/runtime/linux.rs:1112:22
     |
1112 |     ScmpArchX86_64 = 0xc000003e,
     |                      ^^^^^^^^^^
     |
     = note: the literal `0xc000003e` (decimal `3221225534`) does not fit into the type `isize` and will become `-1073741762isize`
     = note: `#[deny(overflowing_literals)]` on by default
```

#### Which issue(s) this PR fixes:

N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Anyone relying on Arch type to be a usize will have to explicitly convert it to a u32.

```release-note

```
