### PR TITLE
Use const_format and provide version as static str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ image = []
 runtime = []
 
 [dependencies]
+const_format = "0.2"
 serde = { version = "1.0.129", features = ["derive"] }
 thiserror = "2.0.0"
 serde_json = "1.0.66"

--- a/src/distribution/version.rs
+++ b/src/distribution/version.rs
@@ -1,3 +1,5 @@
+use const_format::formatcp;
+
 /// API incompatible changes.
 pub const VERSION_MAJOR: u32 = 1;
 
@@ -10,9 +12,15 @@ pub const VERSION_PATCH: u32 = 0;
 /// Indicates development branch. Releases will be empty string.
 pub const VERSION_DEV: &str = "-dev";
 
+/// Retrieve the version as static str representation.
+pub const VERSION: &str = formatcp!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}");
+
 /// Retrieve the version as string representation.
+///
+/// Use [`VERSION`] instead.
+#[deprecated]
 pub fn version() -> String {
-    format!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}")
+    VERSION.to_owned()
 }
 
 #[cfg(test)]
@@ -20,7 +28,8 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn version_test() {
-        assert_eq!(version(), "1.0.0-dev".to_string())
+        assert_eq!(VERSION, "1.0.0-dev".to_string())
     }
 }

--- a/src/distribution/version.rs
+++ b/src/distribution/version.rs
@@ -30,6 +30,6 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn version_test() {
-        assert_eq!(VERSION, "1.0.0-dev".to_string())
+        assert_eq!(version(), "1.0.0-dev".to_string())
     }
 }

--- a/src/image/version.rs
+++ b/src/image/version.rs
@@ -1,3 +1,5 @@
+use const_format::formatcp;
+
 /// API incompatible changes.
 pub const VERSION_MAJOR: u32 = 1;
 
@@ -10,9 +12,15 @@ pub const VERSION_PATCH: u32 = 1;
 /// Indicates development branch. Releases will be empty string.
 pub const VERSION_DEV: &str = "-dev";
 
+/// Retrieve the version as static str representation.
+pub const VERSION: &str = formatcp!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}");
+
 /// Retrieve the version as string representation.
+///
+/// Use [`VERSION`] instead.
+#[deprecated]
 pub fn version() -> String {
-    format!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}")
+    VERSION.to_owned()
 }
 
 #[cfg(test)]
@@ -20,6 +28,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn version_test() {
         assert_eq!(version(), "1.0.1-dev".to_string())
     }

--- a/src/runtime/version.rs
+++ b/src/runtime/version.rs
@@ -1,3 +1,5 @@
+use const_format::formatcp;
+
 /// API incompatible changes.
 pub const VERSION_MAJOR: u32 = 1;
 
@@ -10,9 +12,15 @@ pub const VERSION_PATCH: u32 = 2;
 /// Indicates development branch. Releases will be empty string.
 pub const VERSION_DEV: &str = "-dev";
 
+/// Retrieve the version as static str representation.
+pub const VERSION: &str = formatcp!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}");
+
 /// Retrieve the version as string representation.
+///
+/// Use [`VERSION`] instead.
+#[deprecated]
 pub fn version() -> String {
-    format!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}{VERSION_DEV}")
+    VERSION.to_owned()
 }
 
 #[cfg(test)]
@@ -20,6 +28,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn version_test() {
         assert_eq!(version(), "1.0.2-dev".to_string())
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind api-change

#### What this PR does / why we need it:

This PR is a slight change that makes version available as a `&'static str` instead of `String`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

This PR does not bump the crate version. Although it doesn't contain any breaking changes, and it adds a deprecation for the old API.

I suggest a minor version bump.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Expose version as `&'static str` instead of `String`; the old way of getting the version is still available for now, but marked as deprecated.
```
