### PR TITLE
Add netDevices field

### DIFF
--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -97,6 +97,8 @@ pub struct LinuxFeature {
     intel_rdt: Option<IntelRdt>,
     /// The available features related to mount extensions.
     mount_extensions: Option<MountExtensions>,
+    /// The available features related to net devices.
+    net_devices: Option<NetDevices>,
 }
 
 /// Cgroup represents the "cgroup" field.
@@ -300,6 +302,34 @@ pub struct IntelRdt {
 pub struct MountExtensions {
     /// "idMap" field represents the ID mapping support.
     idmap: Option<IDMap>,
+}
+
+/// NetDevices represents the "netDevices" field.
+#[derive(
+    Builder,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    MutGetters,
+    Getters,
+    Setters,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[builder(
+    default,
+    pattern = "owned",
+    setter(into, strip_option),
+    build_fn(error = "OciSpecError")
+)]
+#[getset(get_mut = "pub", get = "pub", set = "pub")]
+pub struct NetDevices {
+    /// "enabled" field represents whether Net Devices support is compiled in.
+    /// Unrelated to whether the host supports Net Devices or not.
+    enabled: Option<bool>,
 }
 
 /// IDMap represents the "idmap" field.
@@ -532,6 +562,9 @@ mod tests {
             "enabled": true
         },
         "intelRdt": {
+            "enabled": true
+        },
+        "netDevices": {
             "enabled": true
         }
     },
@@ -772,6 +805,13 @@ mod tests {
         assert_eq!(
             linux.intel_rdt.as_ref().unwrap(),
             &IntelRdt {
+                enabled: Some(true)
+            }
+        );
+
+        assert_eq!(
+            linux.net_devices.as_ref().unwrap(),
+            &NetDevices {
                 enabled: Some(true)
             }
         );

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -21,6 +21,10 @@ use strum_macros::{Display as StrumDisplay, EnumString};
 /// containers.
 pub struct Linux {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// NetDevices are key-value pairs, keyed by network device name on the host, moved to the container's network namespace.
+    net_devices: Option<HashMap<String, LinuxNetDevice>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// UIDMappings specifies user mappings for supporting user namespaces.
     uid_mappings: Option<Vec<LinuxIdMapping>>,
 
@@ -97,6 +101,8 @@ pub struct Linux {
 impl Default for Linux {
     fn default() -> Self {
         Linux {
+            // Creates empty Hashmap
+            net_devices: None,
             // Creates empty Vec
             uid_mappings: Default::default(),
             // Creates empty Vec
@@ -226,6 +232,33 @@ impl LinuxDeviceType {
             Self::P => "p",
         }
     }
+}
+
+#[derive(
+    Builder,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Getters,
+    MutGetters,
+    Setters,
+    PartialEq,
+    Serialize,
+)]
+#[builder(
+    default,
+    pattern = "owned",
+    setter(into, strip_option),
+    build_fn(error = "OciSpecError")
+)]
+/// LinuxNetDevice represents a single network device to be added to the container's network namespace
+pub struct LinuxNetDevice {
+    #[serde(default)]
+    #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
+    /// Name of the device in the container namespace
+    name: Option<String>,
 }
 
 #[derive(

--- a/src/runtime/test/fixture/sample.json
+++ b/src/runtime/test/fixture/sample.json
@@ -226,6 +226,13 @@
                 "gid": 0
             }
         ],
+        "netDevices": {
+            "eth0": {
+                "name": "container_eth0"
+            },
+            "ens4": {},
+            "ens5": {}
+        },
         "uidMappings": [
             {
                 "containerID": 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:
To comply with the OCI specification, the `netDevices` field needs to be added to the structure.
#### Which issue(s) this PR fixes:
Fixes #272 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Please review the changes related to the addition of the `netDevices` field.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `netDevices` field has been added to the Linux container configuration to align with the OCI specification. This field is optional, and users are not required to include it for the system to function as before. Users can choose to add this new configuration in the new release, but it is not mandatory.

```
