### PR TITLE
add getter for the name field in LinuxNetDevice.

### DIFF
--- a/src/distribution/reference.rs
+++ b/src/distribution/reference.rs
@@ -324,7 +324,7 @@ fn split_domain(name: &str) -> (String, String) {
         domain = DOCKER_HUB_DOMAIN.into();
     }
     if domain == DOCKER_HUB_DOMAIN && !remainder.contains('/') {
-        remainder = format!("{}/{}", DOCKER_HUB_OFFICIAL_REPO_NAME, remainder);
+        remainder = format!("{DOCKER_HUB_OFFICIAL_REPO_NAME}/{remainder}");
     }
 
     (domain, remainder)

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -256,7 +256,7 @@ impl LinuxDeviceType {
 /// LinuxNetDevice represents a single network device to be added to the container's network namespace
 pub struct LinuxNetDevice {
     #[serde(default)]
-    #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
+    #[getset(get_mut = "pub", get = "pub", set = "pub")]
     /// Name of the device in the container namespace
     name: Option<String>,
 }

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -625,7 +625,7 @@ fn exec_cpu_affinity_regex() -> &'static Regex {
 
 fn validate_cpu_affinity(s: &str) -> Result<(), String> {
     if !exec_cpu_affinity_regex().is_match(s) {
-        return Err(format!("Invalid execCPUAffinity format: {}", s));
+        return Err(format!("Invalid execCPUAffinity format: {s}"));
     }
 
     Ok(())

--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -45,3 +45,45 @@ fn test_load_sample_windows_spec() {
     let err = Spec::load(fixture_path);
     assert!(err.is_ok(), "failed to load spec: {err:?}");
 }
+
+#[test]
+fn test_linux_netdevice_lifecycle() {
+    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/runtime/test/fixture/sample.json");
+
+    let spec =
+        Spec::load(fixture_path).unwrap_or_else(|err| panic!("Failed to load spec: {}", err));
+
+    let net_devices = spec.linux.as_ref().unwrap().net_devices().as_ref().unwrap();
+    assert_eq!(net_devices.len(), 3);
+
+    // Get eth0
+    let eth0 = net_devices.get("eth0").unwrap();
+    assert_eq!(eth0.name().as_ref(), Some(&"container_eth0".to_string()));
+
+    // Get ens4
+    let ens4 = net_devices.get("ens4").unwrap();
+    assert_eq!(ens4.name().as_ref(), None);
+
+    // Get ens5
+    let ens5 = net_devices.get("ens5").unwrap();
+    assert_eq!(ens5.name().as_ref(), None);
+
+    // Set ens6
+    let mut net_devices = net_devices.clone();
+    let ens6 = LinuxNetDeviceBuilder::default()
+        .name("ens6".to_string())
+        .build()
+        .unwrap();
+    net_devices.insert("ens6".to_string(), ens6);
+    assert_eq!(net_devices.len(), 4);
+
+    // Get ens6
+    let ens6 = net_devices.get("ens6").unwrap();
+    assert_eq!(ens6.name().as_ref(), Some(&"ens6".to_string()));
+
+    // Change name of ens6
+    let ens6 = net_devices.get_mut("ens6").unwrap();
+    ens6.set_name(Some("ens6_container".to_string()));
+    assert_eq!(ens6.name().as_ref(), Some(&"ens6_container".to_string()));
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug

#### What this PR does / why we need it:
The bug where the getter for the name field of LinuxNetDevice could not retrieve the value has been fixed, and tests have been added.

#### Which issue(s) this PR fixes:
Fixes #277 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Apologies for not noticing this at the stage of #273. Additionally, I have added tests for the `get` and `set` methods to prevent migration issues. Could you please review the test content and let me know if there are any issues?

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
