### PR TITLE
Fix test_canonicalize_rootfs

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -277,7 +277,16 @@ mod tests {
     fn test_canonicalize_rootfs() {
         let rootfs_name = "rootfs";
         let bundle = tempfile::tempdir().expect("failed to create tmp test bundle dir");
-        let rootfs_absolute_path = bundle.path().join(rootfs_name);
+
+        // On macOS, `$TMPDIR` may not point to canonicalized path.
+        // ```
+        // $ echo $TMPDIR; realpath $TMPDIR
+        // /var/folders/_h/j_17023n23s3_50cq_gwhrrc0000gq/T/
+        // /private/var/folders/_h/j_17023n23s3_50cq_gwhrrc0000gq/T
+        // ```
+        let bundle = fs::canonicalize(bundle.path()).expect("failed to canonicalize bundle");
+
+        let rootfs_absolute_path = bundle.join(rootfs_name);
         assert!(
             rootfs_absolute_path.is_absolute(),
             "rootfs path is not absolute path"
@@ -295,7 +304,7 @@ mod tests {
                 .build()
                 .unwrap();
 
-            spec.canonicalize_rootfs(bundle.path())
+            spec.canonicalize_rootfs(&bundle)
                 .expect("failed to canonicalize rootfs");
 
             assert_eq!(
@@ -310,7 +319,7 @@ mod tests {
                 .build()
                 .unwrap();
 
-            spec.canonicalize_rootfs(bundle.path())
+            spec.canonicalize_rootfs(&bundle)
                 .expect("failed to canonicalize rootfs");
 
             assert_eq!(


### PR DESCRIPTION
Test failed on my macOS laptop:

```
thread 'runtime::tests::test_canonicalize_rootfs' panicked at src/runtime/mod.rs:301:13:
assertion `left == right` failed
  left: "/var/folders/_h/j_17023n23s3_50cq_gwhrrc0000gq/T/.tmpDxkid2/rootfs"
 right: "/private/var/folders/_h/j_17023n23s3_50cq_gwhrrc0000gq/T/.tmpDxkid2/rootfs"
```