### PR TITLE
Add Linux memory policy field

### DIFF
--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -95,6 +95,8 @@ pub struct LinuxFeature {
     selinux: Option<Selinux>,
     /// The available features related to Intel RDT.
     intel_rdt: Option<IntelRdt>,
+    /// The available features related to memory policy.
+    memory_policy: Option<MemoryPolicy>,
     /// The available features related to mount extensions.
     mount_extensions: Option<MountExtensions>,
     /// The available features related to net devices.
@@ -275,6 +277,35 @@ pub struct IntelRdt {
     /// "enabled" field represents whether Intel RDT support is compiled in.
     /// Unrelated to whether the host supports Intel RDT or not.
     enabled: Option<bool>,
+}
+
+/// MemoryPolicy represents the "memoryPolicy" field.
+#[derive(
+    Builder,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    MutGetters,
+    Getters,
+    Setters,
+    PartialEq,
+    Serialize,
+)]
+#[serde(rename_all = "camelCase")]
+#[builder(
+    default,
+    pattern = "owned",
+    setter(into, strip_option),
+    build_fn(error = "OciSpecError")
+)]
+#[getset(get_mut = "pub", get = "pub", set = "pub")]
+pub struct MemoryPolicy {
+    /// modes is the list of known memory policy modes, e.g., "MPOL_INTERLEAVE".
+    modes: Option<Vec<String>>,
+    /// flags is the list of known memory policy mode flags, e.g., "MPOL_F_STATIC_NODES".
+    flags: Option<Vec<String>>,
 }
 
 /// MountExtensions represents the "mountExtensions" field.

--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -595,6 +595,22 @@ mod tests {
         "intelRdt": {
             "enabled": true
         },
+        "memoryPolicy": {
+            "modes": [
+                "MPOL_DEFAULT",
+                "MPOL_BIND",
+                "MPOL_INTERLEAVE",
+                "MPOL_WEIGHTED_INTERLEAVE",
+                "MPOL_PREFERRED",
+                "MPOL_PREFERRED_MANY",
+                "MPOL_LOCAL"
+            ],
+            "flags": [
+                "MPOL_F_NUMA_BALANCING",
+                "MPOL_F_RELATIVE_NODES",
+                "MPOL_F_STATIC_NODES"
+            ]
+        },
         "netDevices": {
             "enabled": true
         }
@@ -837,6 +853,26 @@ mod tests {
             linux.intel_rdt.as_ref().unwrap(),
             &IntelRdt {
                 enabled: Some(true)
+            }
+        );
+
+        assert_eq!(
+            linux.memory_policy.as_ref().unwrap(),
+            &MemoryPolicy {
+                modes: Some(vec![
+                    "MPOL_DEFAULT".to_string(),
+                    "MPOL_BIND".to_string(),
+                    "MPOL_INTERLEAVE".to_string(),
+                    "MPOL_WEIGHTED_INTERLEAVE".to_string(),
+                    "MPOL_PREFERRED".to_string(),
+                    "MPOL_PREFERRED_MANY".to_string(),
+                    "MPOL_LOCAL".to_string(),
+                ]),
+                flags: Some(vec![
+                    "MPOL_F_NUMA_BALANCING".to_string(),
+                    "MPOL_F_RELATIVE_NODES".to_string(),
+                    "MPOL_F_STATIC_NODES".to_string(),
+                ]),
             }
         );
 

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1480,7 +1480,6 @@ impl Default for LinuxPersonalityDomain {
     Clone,
     CopyGetters,
     Debug,
-    Default,
     Deserialize,
     Eq,
     Getters,
@@ -1502,16 +1501,25 @@ pub struct LinuxMemoryPolicy {
     /// Mode for the set_mempolicy syscall.
     mode: MemoryPolicyModeType,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[getset(get = "pub", get_mut = "pub", set = "pub")]
+    #[getset(get = "pub", set = "pub")]
     /// Nodes representing the nodemask for the set_mempolicy syscall in comma separated ranges format.
     /// Format: "<node0>-<node1>,<node2>,<node3>-<node4>,..."
-    nodes: Option<String>,
+    nodes: String,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     /// Flags for the set_mempolicy syscall.
     flags: Option<Vec<MemoryPolicyFlagType>>,
+}
+
+impl Default for LinuxMemoryPolicy {
+    fn default() -> Self {
+        Self {
+            mode: MemoryPolicyModeType::MpolDefault,
+            nodes: "0".to_string(), // Default to node 0
+            flags: None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, StrumDisplay, EnumString)]
@@ -1988,7 +1996,7 @@ mod tests {
     fn test_linux_memory_policy_serialization() {
         let memory_policy = LinuxMemoryPolicy {
             mode: MemoryPolicyModeType::MpolInterleave,
-            nodes: Some("0-3,7".to_string()),
+            nodes: "0-3,7".to_string(),
             flags: Some(vec![
                 MemoryPolicyFlagType::MpolFStaticNodes,
                 MemoryPolicyFlagType::MpolFRelativeNodes,
@@ -1999,7 +2007,7 @@ mod tests {
         let deserialized: LinuxMemoryPolicy = serde_json::from_str(&json).unwrap();
 
         assert_eq!(deserialized.mode, MemoryPolicyModeType::MpolInterleave);
-        assert_eq!(deserialized.nodes, Some("0-3,7".to_string()));
+        assert_eq!(deserialized.nodes, "0-3,7".to_string());
         assert_eq!(
             deserialized.flags,
             Some(vec![
@@ -2013,7 +2021,7 @@ mod tests {
     fn test_linux_memory_policy_default() {
         let memory_policy = LinuxMemoryPolicy::default();
         assert_eq!(memory_policy.mode, MemoryPolicyModeType::MpolDefault);
-        assert_eq!(memory_policy.nodes, None);
+        assert_eq!(memory_policy.nodes, "0".to_string());
         assert_eq!(memory_policy.flags, None);
     }
 }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1476,7 +1476,18 @@ impl Default for LinuxPersonalityDomain {
 }
 
 #[derive(
-    Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
+    Builder,
+    Clone,
+    CopyGetters,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Getters,
+    MutGetters,
+    Setters,
+    PartialEq,
+    Serialize,
 )]
 #[serde(rename_all = "camelCase")]
 #[builder(
@@ -1485,17 +1496,20 @@ impl Default for LinuxPersonalityDomain {
     setter(into, strip_option),
     build_fn(error = "OciSpecError")
 )]
-#[getset(get = "pub", set = "pub")]
 /// LinuxMemoryPolicy represents input for the set_mempolicy syscall.
 pub struct LinuxMemoryPolicy {
+    #[getset(get_copy = "pub", set = "pub")]
     /// Mode for the set_mempolicy syscall.
     mode: MemoryPolicyModeType,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", get_mut = "pub", set = "pub")]
     /// Nodes representing the nodemask for the set_mempolicy syscall in comma separated ranges format.
     /// Format: "<node0>-<node1>,<node2>,<node3>-<node4>,..."
-    nodes: String,
+    nodes: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[getset(get = "pub", get_mut = "pub", set = "pub")]
     /// Flags for the set_mempolicy syscall.
     flags: Option<Vec<MemoryPolicyFlagType>>,
 }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1891,4 +1891,129 @@ mod tests {
         let unknown_operator = invalid_seccomp_operator_str.parse::<LinuxSeccompOperator>();
         assert!(unknown_operator.is_err());
     }
+
+    // MemoryPolicyModeType test cases
+    #[test]
+    fn memory_policy_mode_enum_to_string() {
+        let mode_a = MemoryPolicyModeType::MpolDefault;
+        assert_eq!(mode_a.to_string(), "MPOL_DEFAULT");
+
+        let mode_b = MemoryPolicyModeType::MpolBind;
+        assert_eq!(mode_b.to_string(), "MPOL_BIND");
+
+        let mode_c = MemoryPolicyModeType::MpolInterleave;
+        assert_eq!(mode_c.to_string(), "MPOL_INTERLEAVE");
+
+        let mode_d = MemoryPolicyModeType::MpolWeightedInterleave;
+        assert_eq!(mode_d.to_string(), "MPOL_WEIGHTED_INTERLEAVE");
+
+        let mode_e = MemoryPolicyModeType::MpolPreferred;
+        assert_eq!(mode_e.to_string(), "MPOL_PREFERRED");
+
+        let mode_f = MemoryPolicyModeType::MpolPreferredMany;
+        assert_eq!(mode_f.to_string(), "MPOL_PREFERRED_MANY");
+
+        let mode_g = MemoryPolicyModeType::MpolLocal;
+        assert_eq!(mode_g.to_string(), "MPOL_LOCAL");
+    }
+
+    #[test]
+    fn memory_policy_mode_string_to_enum() {
+        let mode_str = "MPOL_INTERLEAVE";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolInterleave);
+
+        let mode_str = "MPOL_BIND";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolBind);
+
+        let mode_str = "MPOL_DEFAULT";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolDefault);
+
+        let mode_str = "MPOL_WEIGHTED_INTERLEAVE";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolWeightedInterleave);
+
+        let mode_str = "MPOL_PREFERRED";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolPreferred);
+
+        let mode_str = "MPOL_PREFERRED_MANY";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolPreferredMany);
+
+        let mode_str = "MPOL_LOCAL";
+        let mode_enum: MemoryPolicyModeType = mode_str.parse().unwrap();
+        assert_eq!(mode_enum, MemoryPolicyModeType::MpolLocal);
+
+        let invalid_mode_str = "INVALID_MODE";
+        let unknown_mode = invalid_mode_str.parse::<MemoryPolicyModeType>();
+        assert!(unknown_mode.is_err());
+    }
+
+    // MemoryPolicyFlagType test cases
+    #[test]
+    fn memory_policy_flag_enum_to_string() {
+        let flag_a = MemoryPolicyFlagType::MpolFNumaBalancing;
+        assert_eq!(flag_a.to_string(), "MPOL_F_NUMA_BALANCING");
+
+        let flag_b = MemoryPolicyFlagType::MpolFRelativeNodes;
+        assert_eq!(flag_b.to_string(), "MPOL_F_RELATIVE_NODES");
+
+        let flag_c = MemoryPolicyFlagType::MpolFStaticNodes;
+        assert_eq!(flag_c.to_string(), "MPOL_F_STATIC_NODES");
+    }
+
+    #[test]
+    fn memory_policy_flag_string_to_enum() {
+        let flag_str = "MPOL_F_NUMA_BALANCING";
+        let flag_enum: MemoryPolicyFlagType = flag_str.parse().unwrap();
+        assert_eq!(flag_enum, MemoryPolicyFlagType::MpolFNumaBalancing);
+
+        let flag_str = "MPOL_F_RELATIVE_NODES";
+        let flag_enum: MemoryPolicyFlagType = flag_str.parse().unwrap();
+        assert_eq!(flag_enum, MemoryPolicyFlagType::MpolFRelativeNodes);
+
+        let flag_str = "MPOL_F_STATIC_NODES";
+        let flag_enum: MemoryPolicyFlagType = flag_str.parse().unwrap();
+        assert_eq!(flag_enum, MemoryPolicyFlagType::MpolFStaticNodes);
+
+        let invalid_flag_str = "INVALID_FLAG";
+        let unknown_flag = invalid_flag_str.parse::<MemoryPolicyFlagType>();
+        assert!(unknown_flag.is_err());
+    }
+
+    #[test]
+    fn test_linux_memory_policy_serialization() {
+        let memory_policy = LinuxMemoryPolicy {
+            mode: MemoryPolicyModeType::MpolInterleave,
+            nodes: Some("0-3,7".to_string()),
+            flags: Some(vec![
+                MemoryPolicyFlagType::MpolFStaticNodes,
+                MemoryPolicyFlagType::MpolFRelativeNodes,
+            ]),
+        };
+
+        let json = serde_json::to_string(&memory_policy).unwrap();
+        let deserialized: LinuxMemoryPolicy = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.mode, MemoryPolicyModeType::MpolInterleave);
+        assert_eq!(deserialized.nodes, Some("0-3,7".to_string()));
+        assert_eq!(
+            deserialized.flags,
+            Some(vec![
+                MemoryPolicyFlagType::MpolFStaticNodes,
+                MemoryPolicyFlagType::MpolFRelativeNodes,
+            ])
+        );
+    }
+
+    #[test]
+    fn test_linux_memory_policy_default() {
+        let memory_policy = LinuxMemoryPolicy::default();
+        assert_eq!(memory_policy.mode, MemoryPolicyModeType::MpolDefault);
+        assert_eq!(memory_policy.nodes, None);
+        assert_eq!(memory_policy.flags, None);
+    }
 }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1503,7 +1503,7 @@ pub struct LinuxMemoryPolicy {
 
     #[getset(get = "pub", set = "pub")]
     /// Nodes representing the nodemask for the set_mempolicy syscall in comma separated ranges format.
-    /// Format: "<node0>-<node1>,<node2>,<node3>-<node4>,..."
+    /// Format: "&lt;node0&gt;-&lt;node1&gt;,&lt;node2&gt;,&lt;node3&gt;-&lt;node4&gt;,..."
     nodes: String,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change
/kind feature

#### What this PR does / why we need it:

This PR adds support for the `linux.memoryPolicy` configuration field that was
introduced in the OCI Runtime Spec
([opencontainers/runtime-spec#1282](https://github.com/opencontainers/runtime-spec/pull/1282)).

- Added a new `LinuxMemoryPolicy` struct with the following fields:
  - `mode: MemoryPolicyModeType` (required, e.g. `MPOL_INTERLEAVE`)
  - `nodes: String` (required, comma-separated ranges such as `0-3,7`)
  - `flags: Option<Vec<MemoryPolicyFlagType>>` (optional, e.g. `MPOL_F_STATIC_NODES`)
- Added enums `MemoryPolicyModeType` and `MemoryPolicyFlagType` with serde
  string mappings matching the spec.
- Extended the `Linux` struct with an optional `memoryPolicy` field.
- Added test coverage for enum string conversions and serialization.

This allows container runtimes that consume this library to correctly parse and
emit OCI configs with NUMA memory policy settings, enabling features such as
`set_mempolicy(2)` to be configured through the spec.

#### Which issue(s) this PR fixes:

https://github.com/youki-dev/youki/issues/3215 (partially related)

#### Special notes for your reviewer:

- This change closely follows the schema and documentation in [opencontainers/runtime-spec#1282](https://github.com/opencontainers/runtime-spec/pull/1282).

#### Does this PR introduce a user-facing change?

```release-note
Add support for `linux.memoryPolicy` as defined in OCI Runtime Spec PR #1282.
This includes new enums for memory policy modes and flags, and a new
`LinuxMemoryPolicy` struct accessible via `Linux.memoryPolicy`.
```
