### PR TITLE
capability: Add support for flexible capability name formats

### DIFF
--- a/src/runtime/capability.rs
+++ b/src/runtime/capability.rs
@@ -680,4 +680,13 @@ mod tests {
         let cap: Capability = serde_json::from_str(serialized).unwrap();
         assert_eq!(cap, Capability::SysAdmin);
     }
+
+    #[test]
+    fn deserialize_one_more_cap_prefix() -> Result<()> {
+        for case in &["SYS_ADMIN", "CAP_CAP_SYS_ADMIN", "cap_CAP_cap_SYS_ADMIN"] {
+            let res: Capability = serde_json::from_str(&format!("\"{case}\""))?;
+            assert_eq!(Capability::SysAdmin, res);
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
Normalize capability names to accept both CAP_XXX and XXX formats. This allows users to specify capabilities with or without the CAP_ prefix, improving its flexibility and reducing configuration errors.

Implementation:
- Strip all "CAP_" prefixes during deserialization

Examples:
  SYS_ADMIN, CAP_SYS_ADMIN, CAP_CAP_SYS_ADMIN -> SYS_ADMIN

Fixes #298

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>