### PR TITLE
Expose function to build reference from a tag and digest

### DIFF
--- a/src/distribution/reference.rs
+++ b/src/distribution/reference.rs
@@ -125,7 +125,6 @@ impl Reference {
     ///     "sha256:abc123...".to_string(),
     /// );
     /// ```
-
     pub fn with_tag_and_digest(
         registry: String,
         repository: String,


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

This PR adds a function `Reference::with_tag_and_digest(...)`, which allows constructing a `Reference` from tag and digest per the OCI spec.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
Added `Reference::with_tag_and_digest(...)`, which allows building a reference from a tag and digest.
```
