### PR TITLE
chore(runtime): update OCI runtime spec version to 1.1.0

### DIFF
--- a/src/runtime/version.rs
+++ b/src/runtime/version.rs
@@ -4,10 +4,10 @@ use const_format::formatcp;
 pub const VERSION_MAJOR: u32 = 1;
 
 /// Changing functionality in a backwards-compatible manner
-pub const VERSION_MINOR: u32 = 0;
+pub const VERSION_MINOR: u32 = 1;
 
 /// Backwards-compatible bug fixes.
-pub const VERSION_PATCH: u32 = 2;
+pub const VERSION_PATCH: u32 = 0;
 
 /// Indicates development branch. Releases will be empty string.
 pub const VERSION_DEV: &str = "-dev";
@@ -30,6 +30,6 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn version_test() {
-        assert_eq!(version(), "1.0.2-dev".to_string())
+        assert_eq!(version(), "1.1.0-dev".to_string())
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

/kind feature

#### What this PR does / why we need it:
Updates the OCI runtime specification version from 1.0.2 to 1.1.0.

This ensures the library aligns with the latest OCI runtime specification,
enabling support for new features introduced in version 1.1.0.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #301 

#### Special notes for your reviewer:
This is a version bump only. No breaking changes are introduced as 1.1.0
is backwards-compatible with 1.0.x.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The OCI runtime specification version has been updated from 1.0.2 to 1.1.0.
```
