### PR TITLE
Added SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1257,7 +1257,7 @@ pub enum LinuxSeccompFilterFlag {
     SeccompFilterFlagSpecAllow,
 
     /// Ensures the process is killable while waiting for notifications. (since linux 5.19)
-    SeccompFilterFlagWaitKillableRecv
+    SeccompFilterFlagWaitKillableRecv,
 }
 
 #[derive(
@@ -1850,6 +1850,9 @@ mod tests {
 
         let type_c = LinuxSeccompFilterFlag::SeccompFilterFlagSpecAllow;
         assert_eq!(type_c.to_string(), "SECCOMP_FILTER_FLAG_SPEC_ALLOW");
+
+        let type_d = LinuxSeccompFilterFlag::SeccompFilterFlagWaitKillableRecv;
+        assert_eq!(type_d.to_string(), "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV");
     }
 
     #[test]
@@ -1873,6 +1876,13 @@ mod tests {
         assert_eq!(
             filter_flag_type_enum,
             LinuxSeccompFilterFlag::SeccompFilterFlagSpecAllow
+        );
+
+        let filter_flag_type_str = "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV";
+        let filter_flag_type_enum: LinuxSeccompFilterFlag = filter_flag_type_str.parse().unwrap();
+        assert_eq!(
+            filter_flag_type_enum,
+            LinuxSeccompFilterFlag::SeccompFilterFlagWaitKillableRecv
         );
 
         let invalid_filter_flag_str = "x";


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds the `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` flag to the `LinuxSeccompFilterFlag` enum.

This flag was introduced in Linux 5.19 and has been added to the [OCI Runtime Specification v1.3.0](https://specs.opencontainers.org/runtime-spec/config-linux/?v=v1.3.0#seccomp). It ensures that a process remains killable (responsive to `SIGKILL`) while it is waiting for a userspace seccomp notification. This is particularly important for container runtimes that use seccomp listeners to handle syscalls in userspace, preventing "uninterruptible" wait states that could hinder container teardown.

#### Which issue(s) this PR fixes:

Fixes # (If you have a specific issue number, enter it here, otherwise: None)

#### Special notes for your reviewer:

The implementation follows the existing pattern for seccomp flags in this crate:

* Added `SeccompFilterFlagWaitKillableRecv` to the `LinuxSeccompFilterFlag` enum.
* Verified the string serialization matches the OCI spec: `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV`.
* Includes the specific kernel version requirement (5.19+) in the documentation comments.

I have also share PR to handle this changes for youki which uses this. This is the PR link

https://github.com/youki-dev/youki/pull/3404

#### Does this PR introduce a user-facing change?

```release-note
Add SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV support to Linux seccomp configuration, aligning with OCI Runtime Spec v1.3.0.

```

