### PR TITLE
refactor: no regexp-based `Reference::try_from`

### DIFF
--- a/src/distribution/reference.rs
+++ b/src/distribution/reference.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
-use std::{convert::TryFrom, sync::OnceLock};
 
-use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -13,19 +11,6 @@ const DOCKER_HUB_DOMAIN_LEGACY: &str = "index.docker.io";
 const DOCKER_HUB_DOMAIN: &str = "docker.io";
 const DOCKER_HUB_OFFICIAL_REPO_NAME: &str = "library";
 const DEFAULT_TAG: &str = "latest";
-/// REFERENCE_REGEXP is the full supported format of a reference. The regexp
-/// is anchored and has capturing groups for name, tag, and digest components.
-const REFERENCE_REGEXP: &str = r"^((?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?/)?[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?)(?::([\w][\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$";
-
-fn reference_regexp() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        RegexBuilder::new(REFERENCE_REGEXP)
-            .size_limit(10 * (1 << 21))
-            .build()
-            .unwrap()
-    })
-}
 
 /// Reasons that parsing a string as a Reference can fail.
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -267,52 +252,42 @@ impl TryFrom<&str> for Reference {
         if s.is_empty() {
             return Err(ParseError::NameEmpty);
         }
-        let captures = match reference_regexp().captures(s) {
-            Some(caps) => caps,
-            None => {
-                return Err(ParseError::ReferenceInvalidFormat);
-            }
-        };
-        let name = &captures[1];
-        let mut tag = captures.get(2).map(|m| m.as_str().to_owned());
-        let digest = captures.get(3).map(|m| m.as_str().to_owned());
-        if tag.is_none() && digest.is_none() {
-            tag = Some(DEFAULT_TAG.into());
+        // A bare ':' or '@' prefix has no name component.
+        if s.starts_with(':') || s.starts_with('@') {
+            return Err(ParseError::ReferenceInvalidFormat);
         }
-        let (registry, repository) = split_domain(name);
-        let reference = Reference {
-            registry,
-            mirror_registry: None,
-            repository,
-            tag,
-            digest,
+
+        // Extract the digest (`@<algo>:<hex>`).
+        let (name_and_tag, digest) = match s.split_once('@') {
+            Some((n, d)) => (n, Some(d)),
+            None => (s, None),
         };
-        if reference.repository().len() > NAME_TOTAL_LENGTH_MAX {
+
+        // Extract the tag.
+        let (name, tag) = split_name_tag(name_and_tag);
+
+        // Get registry / repository.
+        let (registry, repository) = split_domain(name);
+
+        // Length check (repository only).
+        if repository.len() > NAME_TOTAL_LENGTH_MAX {
             return Err(ParseError::NameTooLong);
         }
-        // Digests much always be hex-encoded, ensuring that their hex portion will always be
-        // size*2
-        if let Some(digest) = reference.digest() {
-            match digest.split_once(':') {
-                None => return Err(ParseError::DigestInvalidFormat),
-                Some(("sha256", digest)) => {
-                    if digest.len() != 64 {
-                        return Err(ParseError::DigestInvalidLength);
-                    }
-                }
-                Some(("sha384", digest)) => {
-                    if digest.len() != 96 {
-                        return Err(ParseError::DigestInvalidLength);
-                    }
-                }
-                Some(("sha512", digest)) => {
-                    if digest.len() != 128 {
-                        return Err(ParseError::DigestInvalidLength);
-                    }
-                }
-                Some((_, _)) => return Err(ParseError::DigestUnsupported),
-            }
+
+        // Character validation.
+        validate_repository(&repository)?;
+        if let Some(d) = digest {
+            validate_digest(d)?;
         }
+
+        let reference = match (tag, digest) {
+            (Some(t), Some(d)) => {
+                Reference::with_tag_and_digest(registry, repository, t.to_owned(), d.to_owned())
+            }
+            (Some(t), None) => Reference::with_tag(registry, repository, t.to_owned()),
+            (None, Some(d)) => Reference::with_digest(registry, repository, d.to_owned()),
+            (None, None) => Reference::with_tag(registry, repository, DEFAULT_TAG.to_owned()),
+        };
         Ok(reference)
     }
 }
@@ -363,6 +338,55 @@ fn split_domain(name: &str) -> (String, String) {
     }
 
     (domain, remainder)
+}
+
+/// Split `name[:tag]` into `(name, Option<tag>)`.
+///
+/// A `:` is treated as a tag separator only when it appears after the last `/`
+/// (or when there is no `/`), so that `host:port/repo` is parsed correctly.
+fn split_name_tag(s: &str) -> (&str, Option<&str>) {
+    let last_slash = s.rfind('/');
+    let last_colon = s.rfind(':');
+    match (last_slash, last_colon) {
+        (_, None) => (s, None),
+        (None, Some(c)) => (&s[..c], Some(&s[c + 1..])),
+        (Some(sl), Some(c)) if c > sl => (&s[..c], Some(&s[c + 1..])),
+        _ => (s, None), // colon belongs to host:port — not a tag
+    }
+}
+
+/// Validate that every path component of the repository contains only `[a-z0-9._-]`.
+fn validate_repository(repo: &str) -> Result<(), ParseError> {
+    repo.split('/').try_for_each(|component| {
+        if !component.is_empty() {
+            component.chars().try_for_each(validate_component_char)
+        } else {
+            Err(ParseError::ReferenceInvalidFormat)
+        }
+    })
+}
+
+fn validate_component_char(c: char) -> Result<(), ParseError> {
+    if c.is_ascii_uppercase() {
+        Err(ParseError::NameContainsUppercase)
+    } else if !c.is_ascii_alphanumeric() && c != '.' && c != '_' && c != '-' {
+        Err(ParseError::ReferenceInvalidFormat)
+    } else {
+        Ok(())
+    }
+}
+
+/// Validate a digest string of the form `<algorithm>:<hex>`.
+fn validate_digest(digest: &str) -> Result<(), ParseError> {
+    use ParseError::*;
+    match digest.split_once(':') {
+        Some(("sha256", hex)) if hex.len() == 64 => Ok(()),
+        Some(("sha384", hex)) if hex.len() == 96 => Ok(()),
+        Some(("sha512", hex)) if hex.len() == 128 => Ok(()),
+        Some(("sha256", _)) | Some(("sha384", _)) | Some(("sha512", _)) => Err(DigestInvalidLength),
+        Some(_) => Err(DigestUnsupported),
+        None => Err(DigestInvalidFormat),
+    }
 }
 
 #[cfg(test)]
@@ -418,13 +442,11 @@ mod test {
             case("@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", ParseError::ReferenceInvalidFormat),
             case("repo@sha256:ffffffffffffffffffffffffffffffffff", ParseError::DigestInvalidLength),
             case("validname@invaliddigest:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", ParseError::DigestUnsupported),
-            // FIXME: should really pass a ParseError::NameContainsUppercase, but "invalid format" is good enough for now.
-            case("Uppercase:tag", ParseError::ReferenceInvalidFormat),
+            case("Uppercase:tag", ParseError::NameContainsUppercase),
             // FIXME: "Uppercase" is incorrectly handled as a domain-name here, and therefore passes.
             // https://github.com/docker/distribution/blob/master/reference/reference_test.go#L104-L109
             // case("Uppercase/lowercase:tag", ParseError::NameContainsUppercase),
-            // FIXME: should really pass a ParseError::NameContainsUppercase, but "invalid format" is good enough for now.
-            case("test:5000/Uppercase/lowercase:tag", ParseError::ReferenceInvalidFormat),
+            case("test:5000/Uppercase/lowercase:tag", ParseError::NameContainsUppercase),
             case("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ParseError::NameTooLong),
             case("aa/asdf$$^/aa", ParseError::ReferenceInvalidFormat)
         )]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind other
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

During execution of a program that has `oci-spec` as a dependency and performs `Reference::from_str` from different threads (we found this when calling that function from only one thread at a time of a multi-threaded program) we noticed, besides the initial hit when the regexp gets stored in the `OnceLock`, regular increases of around 6 MB of RSS that were not freed even after the thread was joined.

I have set up a reproducer at https://github.com/DavSanchez/oci-parse-threaded-repro that shows the behaviour. It only spawns threads one at a time, calls `Reference::from_str` on a string that switches back and forth between 2 alternatives (but check the README for reports of using more than 2 possible strings), sleeps, calls `ps` and prints to `stdout`.

It also contains some example logs of running the reproducer using this crate as-is and with the fork. Also included DHAT reports for both and a way to generate your own via a feature using the `dhat` crate. See the `darwin-reports` and `linux-reports` directories to find these reports.

This is an example of one of these reports comparing the RSS of the current implementation vs the fork, on an `aarch64-linux` VM.

| cycle | rss (KB) upstream | rss (KB) fork |
| ----- | ----------------- | ------------- |
| 0     | 15092             | 512           |
| 1     | 15220             | 512           |
| 2     | 20980             | 512           |
| 3     | 21236             | 512           |
| 4     | 26868             | 512           |
| 5     | 27124             | 512           |
| 6     | 32884             | 512           |
| 7     | 33140             | 512           |
| 8     | 38900             | 512           |
| 9     | 38900             | 512           |

*same values after this for 80 threads, but increasing the number of OCI refs to parse increases the cap of the current implementation (e.g. to 75+ MB for 8 refs) while keeping flat on the forked version.

We thought that for our use case these allocated amounts were too high and tried with an approach that hopefully covers your expected usage but does not use the regexp, allocating a fraction of the amount. It only replaces the `Reference::try_from` implementation for `&str` and adds a couple helper functions. It passes all existing tests in the module which have not been altered.

As an additional datapoint, our program got its reported RSS cut by half when switching to use the forked repo, having performed a single `Reference::from_str` on each of the runs:

<img width="3646" height="1540" alt="image" src="https://github.com/user-attachments/assets/9c326277-9bfd-4dee-90d3-ea12e5e30082" />

Also took the chance to address some of the `FIXME`s in the tests.

Let us know your thoughts!

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```