### PR TITLE
builder: Replace derive_builder with bon to drop pervasive unwrap()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.129", features = ["derive"] }
 thiserror = "2.0.0"
 serde_json = "1.0.66"
 quickcheck = { version = "1.0.3", optional = true }
-derive_builder = "0.20.0"
+bon = "3"
 getset = "0.1.3"
 strum = "0.27.0"
 strum_macros = "0.27.0"

--- a/README.md
+++ b/README.md
@@ -40,21 +40,18 @@ assert_eq!(image_manifest.layers().len(), 5);
 ```rust no_run
 use std::str::FromStr;
 use oci_spec::image::{
-    Descriptor, 
-    DescriptorBuilder, 
-    ImageManifest, 
-    ImageManifestBuilder, 
+    Descriptor,
+    ImageManifest,
     MediaType, 
     Sha256Digest,
     SCHEMA_VERSION
 };
 
-let config = DescriptorBuilder::default()
+let config = Descriptor::builder()
             .media_type(MediaType::ImageConfig)
             .size(7023u64)
             .digest(Sha256Digest::from_str("b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7").unwrap())
-            .build()
-            .expect("build config descriptor");
+            .build();
 
 let layers: Vec<Descriptor> = [
     (
@@ -72,21 +69,19 @@ let layers: Vec<Descriptor> = [
 ]
     .iter()
     .map(|l| {
-    DescriptorBuilder::default()
+    Descriptor::builder()
         .media_type(MediaType::ImageLayerGzip)
         .size(l.0)
         .digest(Sha256Digest::from_str(l.1).unwrap())
         .build()
-        .expect("build layer")
     })
     .collect();
 
-let image_manifest = ImageManifestBuilder::default()
+let image_manifest = ImageManifest::builder()
     .schema_version(SCHEMA_VERSION)
     .config(config)
     .layers(layers)
-    .build()
-    .expect("build image manifest");
+    .build();
 
 image_manifest.to_file_pretty("my-manifest.json").unwrap();
 ```
@@ -123,11 +118,11 @@ image_manifest.to_file_pretty("my-manifest.json").unwrap();
 ## Distribution Spec Examples
 - Create a list of repositories 
 ```rust
-use oci_spec::distribution::RepositoryListBuilder;
+use oci_spec::distribution::RepositoryList;
 
-let list = RepositoryListBuilder::default()
+let list = RepositoryList::builder()
             .repositories(vec!["busybox".to_owned()])
-            .build().unwrap();
+            .build();
 ```
 
 # Contributing

--- a/src/distribution/error.rs
+++ b/src/distribution/error.rs
@@ -1,7 +1,6 @@
 //! Error types of the distribution spec.
 
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -48,11 +47,7 @@ pub enum ErrorCode {
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Error, Getters, PartialEq, Serialize)]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub")]
 /// ErrorResponse is returned by a registry on an invalid request.
 pub struct ErrorResponse {
@@ -74,11 +69,7 @@ impl ErrorResponse {
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, PartialEq, Serialize)]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub")]
 /// Describes a server error returned from a registry.
 pub struct ErrorInfo {
@@ -87,13 +78,11 @@ pub struct ErrorInfo {
     code: ErrorCode,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default = "None")]
     /// The message field is OPTIONAL, and if present, it SHOULD be a human readable string or
     /// MAY be empty.
     message: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none", with = "json_string")]
-    #[builder(default = "None")]
     /// The detail field is OPTIONAL and MAY contain arbitrary JSON data providing information
     /// the client can use to resolve the issue.
     detail: Option<String>,
@@ -142,61 +131,44 @@ mod json_string {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::Result;
 
     #[test]
-    fn error_response_success() -> Result<()> {
-        let response = ErrorResponseBuilder::default().errors(vec![]).build()?;
+    fn error_response_success() {
+        let response = ErrorResponse::builder().errors(vec![]).build();
         assert!(response.detail().is_empty());
         assert_eq!(response.to_string(), ERR_REGISTRY);
-        Ok(())
     }
 
     #[test]
-    fn error_response_failure() {
-        assert!(ErrorResponseBuilder::default().build().is_err());
-    }
-
-    #[test]
-    fn error_info_success() -> Result<()> {
-        let info = ErrorInfoBuilder::default()
-            .code(ErrorCode::BlobUnknown)
-            .build()?;
+    fn error_info_success() {
+        let info = ErrorInfo::builder().code(ErrorCode::BlobUnknown).build();
         assert_eq!(info.code(), &ErrorCode::BlobUnknown);
         assert!(info.message().is_none());
         assert!(info.detail().is_none());
-        Ok(())
     }
 
     #[test]
-    fn error_info_failure() {
-        assert!(ErrorInfoBuilder::default().build().is_err());
-    }
-
-    #[test]
-    fn error_info_serialize_success() -> Result<()> {
-        let error_info = ErrorInfoBuilder::default()
+    fn error_info_serialize_success() {
+        let error_info = ErrorInfo::builder()
             .code(ErrorCode::Unauthorized)
             .detail(String::from("{ \"key\": \"value\" }"))
-            .build()?;
+            .build();
 
         assert!(serde_json::to_string(&error_info).is_ok());
-        Ok(())
     }
 
     #[test]
-    fn error_info_serialize_failure() -> Result<()> {
-        let error_info = ErrorInfoBuilder::default()
+    fn error_info_serialize_failure() {
+        let error_info = ErrorInfo::builder()
             .code(ErrorCode::Unauthorized)
             .detail(String::from("abcd"))
-            .build()?;
+            .build();
 
         assert!(serde_json::to_string(&error_info).is_err());
-        Ok(())
     }
 
     #[test]
-    fn error_info_deserialize_success() -> Result<()> {
+    fn error_info_deserialize_success() {
         let error_info_str = r#"
         {
             "code": "MANIFEST_UNKNOWN",
@@ -206,9 +178,7 @@ mod tests {
             }
         }"#;
 
-        let error_info: ErrorInfo = serde_json::from_str(error_info_str)?;
+        let error_info: ErrorInfo = serde_json::from_str(error_info_str).unwrap();
         assert_eq!(error_info.detail().as_ref().unwrap(), "{\"Tag\":\"lates\"}");
-
-        Ok(())
     }
 }

--- a/src/distribution/repository.rs
+++ b/src/distribution/repository.rs
@@ -1,16 +1,11 @@
 //! Repository types of the distribution spec.
 
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// RepositoryList returns a catalog of repositories maintained on the registry.
 pub struct RepositoryList {
@@ -21,19 +16,10 @@ pub struct RepositoryList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::Result;
 
     #[test]
-    fn repository_list_success() -> Result<()> {
-        let list = RepositoryListBuilder::default()
-            .repositories(vec![])
-            .build()?;
+    fn repository_list_success() {
+        let list = RepositoryList::builder().repositories(vec![]).build();
         assert!(list.repositories().is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn repository_list_failure() {
-        assert!(RepositoryListBuilder::default().build().is_err());
     }
 }

--- a/src/distribution/tag.rs
+++ b/src/distribution/tag.rs
@@ -1,16 +1,11 @@
 //! Tag types of the distribution spec.
 
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// A list of tags for a given repository.
 pub struct TagList {
@@ -24,21 +19,11 @@ pub struct TagList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::Result;
 
     #[test]
-    fn tag_list_success() -> Result<()> {
-        let list = TagListBuilder::default()
-            .name("name")
-            .tags(vec![])
-            .build()?;
+    fn tag_list_success() {
+        let list = TagList::builder().name("name").tags(vec![]).build();
         assert!(list.tags().is_empty());
         assert_eq!(list.name(), "name");
-        Ok(())
-    }
-
-    #[test]
-    fn tag_list_failure() {
-        assert!(TagListBuilder::default().build().is_err());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,6 @@ pub enum OciSpecError {
     /// serialization or deserialization.
     #[error("serde failed")]
     SerDe(#[from] serde_json::Error),
-
-    /// Builder specific errors.
-    #[error("uninitialized field")]
-    Builder(#[from] derive_builder::UninitializedFieldError),
 }
 
 pub(crate) fn oci_error<'a, M>(message: M) -> OciSpecError

--- a/src/image/artifact.rs
+++ b/src/image/artifact.rs
@@ -1,6 +1,6 @@
 use super::{Descriptor, MediaType};
-use crate::error::{OciSpecError, Result};
-use derive_builder::Builder;
+use crate::error::Result;
+use bon::Builder;
 use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -13,19 +13,14 @@ use std::{
     Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// The OCI Artifact manifest describes content addressable artifacts
 /// in order to store them along side container images in a registry.
 pub struct ArtifactManifest {
     /// This property MUST be used and contain the media type
     /// `application/vnd.oci.artifact.manifest.v1+json`.
     #[getset(get = "pub")]
-    #[builder(default = "MediaType::ArtifactManifest")]
-    #[builder(setter(skip))]
+    #[builder(skip = MediaType::ArtifactManifest)]
     media_type: MediaType,
 
     /// This property SHOULD be used and contain
@@ -49,7 +44,6 @@ pub struct ArtifactManifest {
     /// to the specified manifest.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     subject: Option<Descriptor>,
 
     /// This OPTIONAL property contains additional metadata for the artifact
@@ -58,7 +52,6 @@ pub struct ArtifactManifest {
     /// the response from the referrers API.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get_mut = "pub", get = "pub", set = "pub")]
-    #[builder(default)]
     annotations: Option<HashMap<String, String>>,
 }
 
@@ -216,7 +209,7 @@ impl ArtifactManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::image::{DescriptorBuilder, Sha256Digest};
+    use crate::image::Sha256Digest;
     use std::{path::PathBuf, str::FromStr};
 
     fn get_manifest_path() -> PathBuf {
@@ -224,7 +217,7 @@ mod tests {
     }
 
     fn create_manifest() -> ArtifactManifest {
-        let blob = DescriptorBuilder::default()
+        let blob = Descriptor::builder()
             .media_type(MediaType::Other("application/gzip".to_string()))
             .size(123u64)
             .digest(
@@ -233,9 +226,8 @@ mod tests {
                 )
                 .unwrap(),
             )
-            .build()
-            .unwrap();
-        let subject = DescriptorBuilder::default()
+            .build();
+        let subject = Descriptor::builder()
             .media_type(MediaType::ImageManifest)
             .size(1234u64)
             .digest(
@@ -244,8 +236,7 @@ mod tests {
                 )
                 .unwrap(),
             )
-            .build()
-            .unwrap();
+            .build();
         let annotations = HashMap::from([
             (
                 "org.opencontainers.artifact.created".to_string(),
@@ -253,7 +244,7 @@ mod tests {
             ),
             ("org.example.sbom.format".to_string(), "json".to_string()),
         ]);
-        ArtifactManifestBuilder::default()
+        ArtifactManifest::builder()
             .artifact_type(MediaType::Other(
                 "application/vnd.example.sbom.v1".to_string(),
             ))
@@ -261,7 +252,6 @@ mod tests {
             .subject(subject)
             .annotations(annotations)
             .build()
-            .unwrap()
     }
 
     #[test]

--- a/src/image/config.rs
+++ b/src/image/config.rs
@@ -1,9 +1,6 @@
 use super::{Arch, Os};
-use crate::{
-    error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_string, to_writer,
-};
-use derive_builder::Builder;
+use crate::{error::Result, from_file, from_reader, to_file, to_string, to_writer};
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(test)]
@@ -32,12 +29,7 @@ pub const LABEL_VERSION: &str = "version";
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// The image configuration is associated with an image and describes some
 /// basic information about the image such as date created, author, as
@@ -282,12 +274,7 @@ impl Display for ImageConfiguration {
     Serialize,
 )]
 #[serde(rename_all = "PascalCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// The execution parameters which SHOULD be used as a base when
 /// running a container using the image.
@@ -419,12 +406,7 @@ where
 #[derive(
     Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// RootFs references the layer content addresses used by the image.
 pub struct RootFs {
@@ -459,12 +441,7 @@ impl Default for RootFs {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Describes the history of a layer.
 pub struct History {
     /// A combined date and time at which the layer was created,
@@ -499,8 +476,8 @@ mod tests {
     use super::*;
     use crate::image::{ANNOTATION_CREATED, ANNOTATION_VERSION};
 
-    fn create_base_config() -> ConfigBuilder {
-        ConfigBuilder::default()
+    fn create_base_config() -> Config {
+        Config::builder()
             .user("alice".to_owned())
             .exposed_ports(vec!["8080/tcp".to_owned()])
             .env(vec![
@@ -519,42 +496,39 @@ mod tests {
                 "/var/log/my-app-logs".to_owned(),
             ])
             .working_dir("/home/alice".to_owned())
+            .build()
     }
 
-    fn create_base_imgconfig(conf: Config) -> ImageConfigurationBuilder {
-        ImageConfigurationBuilder::default()
+    fn create_base_imgconfig(conf: Config) -> ImageConfiguration {
+        ImageConfiguration::builder()
             .created("2015-10-31T22:22:56.015925234Z".to_owned())
             .author("Alyssa P. Hacker <alyspdev@example.com>".to_owned())
             .architecture(Arch::Amd64)
             .os(Os::Linux)
-            .config(conf
-            )
-            .rootfs(RootFsBuilder::default()
+            .config(conf)
+            .rootfs(RootFs::builder()
+            .typ("layers")
             .diff_ids(vec![
                 "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1".to_owned(),
                 "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef".to_owned(),
             ])
-            .build()
-            .expect("build rootfs"))
+            .build())
             .history(vec![
-                HistoryBuilder::default()
+                History::builder()
                 .created("2015-10-31T22:22:54.690851953Z".to_owned())
                 .created_by("/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /".to_owned())
-                .build()
-                .expect("build history"),
-                HistoryBuilder::default()
+                .build(),
+                History::builder()
                 .created("2015-10-31T22:22:55.613815829Z".to_owned())
                 .created_by("/bin/sh -c #(nop) CMD [\"sh\"]".to_owned())
                 .empty_layer(true)
-                .build()
-                .expect("build history"),
+                .build(),
             ])
+            .build()
     }
 
     fn create_config() -> ImageConfiguration {
-        create_base_imgconfig(create_base_config().build().expect("config"))
-            .build()
-            .expect("build configuration")
+        create_base_imgconfig(create_base_config())
     }
 
     /// A config with some additions (labels)
@@ -565,11 +539,9 @@ mod tests {
         ]
         .into_iter()
         .map(|(k, v)| (k.to_owned(), v.to_owned()));
-        let config = create_base_config()
-            .labels(labels.collect::<HashMap<_, _>>())
-            .build()
-            .unwrap();
-        create_base_imgconfig(config).build().unwrap()
+        let mut config = create_base_config();
+        config.set_labels(Some(labels.collect::<HashMap<_, _>>()));
+        create_base_imgconfig(config)
     }
 
     fn get_config_path() -> PathBuf {
@@ -680,17 +652,16 @@ mod tests {
 
     #[test]
     fn serialize_without_history() {
-        let config = ImageConfigurationBuilder::default()
+        let config = ImageConfiguration::builder()
             .architecture(Arch::Amd64)
             .os(Os::Linux)
             .rootfs(
-                RootFsBuilder::default()
+                RootFs::builder()
+                    .typ("layers")
                     .diff_ids(vec!["sha256:abc123".to_owned()])
-                    .build()
-                    .expect("build rootfs"),
+                    .build(),
             )
-            .build()
-            .expect("build config");
+            .build();
 
         let json = config.to_string().expect("serialize");
         assert!(!json.contains("history"));
@@ -698,17 +669,16 @@ mod tests {
 
     #[test]
     fn builder_without_history() {
-        let config = ImageConfigurationBuilder::default()
+        let config = ImageConfiguration::builder()
             .architecture(Arch::Amd64)
             .os(Os::Linux)
             .rootfs(
-                RootFsBuilder::default()
+                RootFs::builder()
+                    .typ("layers")
                     .diff_ids(vec!["sha256:abc123".to_owned()])
-                    .build()
-                    .expect("build rootfs"),
+                    .build(),
             )
-            .build()
-            .expect("build config");
+            .build();
 
         assert!(config.history().is_none());
     }

--- a/src/image/descriptor.rs
+++ b/src/image/descriptor.rs
@@ -1,6 +1,5 @@
 use super::{Arch, Digest, MediaType, Os};
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -9,11 +8,7 @@ use std::collections::HashMap;
     Builder, Clone, CopyGetters, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// A Content Descriptor (or simply Descriptor) describes the disposition of
 /// the targeted content. It includes the type of the content, a content
 /// identifier (digest), and the byte-size of the raw content.
@@ -44,21 +39,18 @@ pub struct Descriptor {
     /// in [RFC 7230](https://tools.ietf.org/html/rfc7230#section-2.7).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     urls: Option<Vec<String>>,
     /// This OPTIONAL property contains arbitrary metadata for this
     /// descriptor. This OPTIONAL property MUST use the annotation
     /// rules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     annotations: Option<HashMap<String, String>>,
     /// This OPTIONAL property describes the minimum runtime requirements of
     /// the image. This property SHOULD be present if its target is
     /// platform-specific.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     platform: Option<Platform>,
     /// This OPTIONAL property contains the type of an artifact when the descriptor points to an
     /// artifact. This is the value of the config descriptor mediaType when the descriptor
@@ -66,7 +58,6 @@ pub struct Descriptor {
     /// the naming requirements in its section 4.2, and MAY be registered with IANA.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     artifact_type: Option<MediaType>,
     /// This OPTIONAL property contains an embedded representation of the referenced content.
     /// Values MUST conform to the Base 64 encoding, as defined in RFC 4648. The decoded data MUST
@@ -74,18 +65,13 @@ pub struct Descriptor {
     /// fields by content consumers. See Embedded Content for when this is appropriate.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     data: Option<String>,
 }
 
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// Describes the minimum runtime requirements of the image.
 pub struct Platform {
@@ -103,7 +89,6 @@ pub struct Platform {
     /// version. Valid values are implementation-defined. e.g.
     /// 10.0.14393.1066 on windows.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default)]
     os_version: Option<String>,
     /// This OPTIONAL property specifies an array of strings, each
     /// specifying a mandatory OS feature. When os is windows, image
@@ -115,7 +100,6 @@ pub struct Platform {
     /// When os is not windows, values are implementation-defined and SHOULD
     /// be submitted to this specification for standardization.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default)]
     os_features: Option<Vec<String>>,
     /// This OPTIONAL property specifies the variant of the CPU.
     /// Image indexes SHOULD use, and implementations SHOULD understand,
@@ -123,11 +107,9 @@ pub struct Platform {
     /// (<https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants>)
     /// table.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default)]
     variant: Option<String>,
     /// This property is RESERVED for future versions of the specification.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default)]
     features: Option<Vec<String>>,
 }
 

--- a/src/image/index.rs
+++ b/src/image/index.rs
@@ -1,9 +1,6 @@
 use super::{Descriptor, MediaType};
-use crate::{
-    error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_string, to_writer,
-};
-use derive_builder::Builder;
+use crate::{error::Result, from_file, from_reader, to_file, to_string, to_writer};
+use bon::Builder;
 use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -20,11 +17,7 @@ pub const SCHEMA_VERSION: u32 = 2;
     Builder, Clone, CopyGetters, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// The image index is a higher-level manifest which points to specific
 /// image manifests, ideal for one or more platforms. While the use of
 /// an image index is OPTIONAL for image providers, image consumers
@@ -42,14 +35,12 @@ pub struct ImageIndex {
     /// which differs from the descriptor use of mediaType.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     media_type: Option<MediaType>,
     /// This OPTIONAL property contains the type of an artifact when the manifest is used for an
     /// artifact. If defined, the value MUST comply with RFC 6838, including the naming
     /// requirements in its section 4.2, and MAY be registered with IANA.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     artifact_type: Option<MediaType>,
     /// This REQUIRED property contains a list of manifests for specific
     /// platforms. While this property MUST be present, the size of
@@ -60,13 +51,11 @@ pub struct ImageIndex {
     /// referrers API, indicates a relationship to the specified manifest.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     subject: Option<Descriptor>,
     /// This OPTIONAL property contains arbitrary metadata for the image
     /// index. This OPTIONAL property MUST use the annotation rules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get_mut = "pub", get = "pub", set = "pub")]
-    #[builder(default)]
     annotations: Option<HashMap<String, String>>,
 }
 
@@ -234,10 +223,10 @@ mod tests {
 
     use super::*;
     use crate::image::{Arch, Os, Sha256Digest};
-    use crate::image::{DescriptorBuilder, PlatformBuilder};
+    use crate::image::{Descriptor, Platform};
 
     fn create_index() -> ImageIndex {
-        let ppc_manifest = DescriptorBuilder::default()
+        let ppc_manifest = Descriptor::builder()
             .media_type(MediaType::ImageManifest)
             .digest(
                 Sha256Digest::from_str(
@@ -247,16 +236,14 @@ mod tests {
             )
             .size(7143u64)
             .platform(
-                PlatformBuilder::default()
+                Platform::builder()
                     .architecture(Arch::PowerPC64le)
                     .os(Os::Linux)
-                    .build()
-                    .expect("build ppc64le platform"),
+                    .build(),
             )
-            .build()
-            .expect("build ppc manifest descriptor");
+            .build();
 
-        let amd64_manifest = DescriptorBuilder::default()
+        let amd64_manifest = Descriptor::builder()
             .media_type(MediaType::ImageManifest)
             .digest(
                 Sha256Digest::from_str(
@@ -266,20 +253,17 @@ mod tests {
             )
             .size(7682u64)
             .platform(
-                PlatformBuilder::default()
+                Platform::builder()
                     .architecture(Arch::Amd64)
                     .os(Os::Linux)
-                    .build()
-                    .expect("build amd64 platform"),
+                    .build(),
             )
-            .build()
-            .expect("build amd64 manifest descriptor");
+            .build();
 
-        ImageIndexBuilder::default()
+        ImageIndex::builder()
             .schema_version(SCHEMA_VERSION)
             .manifests(vec![ppc_manifest, amd64_manifest])
             .build()
-            .expect("build image index")
     }
 
     fn get_index_path() -> PathBuf {

--- a/src/image/manifest.rs
+++ b/src/image/manifest.rs
@@ -1,9 +1,6 @@
 use super::{Descriptor, MediaType};
-use crate::{
-    error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_string, to_writer,
-};
-use derive_builder::Builder;
+use crate::{error::Result, from_file, from_reader, to_file, to_string, to_writer};
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -27,11 +24,7 @@ use std::{
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Unlike the image index, which contains information about a set of images
 /// that can span a variety of architectures and operating systems, an image
 /// manifest provides a configuration and set of layers for a single
@@ -49,7 +42,6 @@ pub struct ImageManifest {
     /// which differs from the descriptor use of mediaType.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     media_type: Option<MediaType>,
     /// This OPTIONAL property contains the type of an artifact when the manifest is used for an
     /// artifact. This MUST be set when config.mediaType is set to the empty value. If defined, the
@@ -58,7 +50,6 @@ pub struct ImageManifest {
     /// error on encountering an artifactType that is unknown to the implementation.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     artifact_type: Option<MediaType>,
     /// This REQUIRED property references a configuration object for a
     /// container, by digest. Beyond the descriptor requirements,
@@ -84,14 +75,12 @@ pub struct ImageManifest {
     /// referrers API, indicates a relationship to the specified manifest.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
-    #[builder(default)]
     subject: Option<Descriptor>,
     /// This OPTIONAL property contains arbitrary metadata for the image
     /// manifest. This OPTIONAL property MUST use the annotation
     /// rules.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get_mut = "pub", get = "pub", set = "pub")]
-    #[builder(default)]
     annotations: Option<HashMap<String, String>>,
 }
 
@@ -244,12 +233,12 @@ mod tests {
     use std::{fs, path::PathBuf, str::FromStr};
 
     use super::*;
-    use crate::image::{DescriptorBuilder, Sha256Digest};
+    use crate::image::Sha256Digest;
 
     fn create_manifest() -> ImageManifest {
         use crate::image::SCHEMA_VERSION;
 
-        let config = DescriptorBuilder::default()
+        let config = Descriptor::builder()
             .media_type(MediaType::ImageConfig)
             .size(7023u64)
             .digest(
@@ -257,8 +246,7 @@ mod tests {
                     .parse::<Sha256Digest>()
                     .unwrap(),
             )
-            .build()
-            .expect("build config descriptor");
+            .build();
 
         let layers: Vec<Descriptor> = [
             (
@@ -276,21 +264,19 @@ mod tests {
         ]
         .iter()
         .map(|l| {
-            DescriptorBuilder::default()
+            Descriptor::builder()
                 .media_type(MediaType::ImageLayerGzip)
                 .size(l.0)
                 .digest(Sha256Digest::from_str(l.1).unwrap())
                 .build()
-                .expect("build layer")
         })
         .collect();
 
-        ImageManifestBuilder::default()
+        ImageManifest::builder()
             .schema_version(SCHEMA_VERSION)
             .config(config)
             .layers(layers)
             .build()
-            .expect("build image manifest")
     }
 
     fn get_manifest_path() -> PathBuf {

--- a/src/image/oci_layout.rs
+++ b/src/image/oci_layout.rs
@@ -1,8 +1,5 @@
-use crate::{
-    error::{OciSpecError, Result},
-    from_file, from_reader, to_file, to_string, to_writer,
-};
-use derive_builder::Builder;
+use crate::{error::Result, from_file, from_reader, to_file, to_string, to_writer};
+use bon::Builder;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -12,11 +9,7 @@ use std::{
 
 #[derive(Builder, Clone, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// The oci layout JSON object serves as a marker for the base of an Open Container Image Layout
 /// and to provide the version of the image-layout in use. The imageLayoutVersion value will align
 /// with the OCI Image Specification version at the time changes to the layout are made, and will
@@ -162,10 +155,9 @@ mod tests {
     use super::*;
 
     fn create_oci_layout() -> OciLayout {
-        OciLayoutBuilder::default()
+        OciLayout::builder()
             .image_layout_version("lorem ipsum")
             .build()
-            .expect("build oci layout")
     }
 
     fn get_oci_layout_path() -> PathBuf {

--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 
-use crate::{
-    error::OciSpecError,
-    runtime::{Arch, LinuxNamespaceType, LinuxSeccompAction},
-};
-use derive_builder::Builder;
+use crate::runtime::{Arch, LinuxNamespaceType, LinuxSeccompAction};
+use bon::Builder;
 use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 
@@ -26,12 +23,7 @@ use serde::{Deserialize, Serialize};
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Features {
     /// The minimum OCI Runtime Spec version recognized by the runtime, e.g., "1.0.0".
@@ -71,12 +63,7 @@ pub struct Features {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct LinuxFeature {
     /// The list of the recognized namespaces, e.g., "mount".
@@ -118,12 +105,7 @@ pub struct LinuxFeature {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Cgroup {
     /// "v1" field represents whether Cgroup v1 support is compiled in.
@@ -163,12 +145,7 @@ pub struct Cgroup {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Seccomp {
     /// "enabled" field represents whether seccomp support is compiled in.
@@ -208,12 +185,7 @@ pub struct Seccomp {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Apparmor {
     /// "enabled" field represents whether AppArmor support is compiled in.
@@ -237,12 +209,7 @@ pub struct Apparmor {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Selinux {
     /// "enabled" field represents whether SELinux support is compiled in.
@@ -266,12 +233,7 @@ pub struct Selinux {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct IntelRdt {
     /// "enabled" field represents whether Intel RDT support is compiled in.
@@ -294,12 +256,7 @@ pub struct IntelRdt {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct MemoryPolicy {
     /// modes is the list of known memory policy modes, e.g., "MPOL_INTERLEAVE".
@@ -323,12 +280,7 @@ pub struct MemoryPolicy {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct MountExtensions {
     /// "idMap" field represents the ID mapping support.
@@ -350,12 +302,7 @@ pub struct MountExtensions {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct NetDevices {
     /// "enabled" field represents whether Net Devices support is compiled in.
@@ -378,12 +325,7 @@ pub struct NetDevices {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct IDMap {
     /// "enabled" field represents whether idmap mounts supports is compiled in.

--- a/src/runtime/hooks.rs
+++ b/src/runtime/hooks.rs
@@ -1,5 +1,4 @@
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -18,12 +17,7 @@ use std::path::PathBuf;
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 /// Hooks specifies a command that is run in the container at a particular
 /// event in the lifecycle (setup and teardown) of a container.
@@ -90,12 +84,7 @@ pub struct Hooks {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Hook specifies a command that is run at a particular event in the
 /// lifecycle of a container.
 pub struct Hook {

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1,6 +1,6 @@
 use crate::error::{oci_error, OciSpecError};
 
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display, path::PathBuf, vec};
@@ -10,12 +10,7 @@ use strum_macros::{Display as StrumDisplay, EnumString};
     Builder, Clone, Debug, Deserialize, Eq, Getters, MutGetters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 /// Linux contains platform-specific configuration for Linux based
 /// containers.
@@ -175,25 +170,23 @@ impl Linux {
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxIDMapping specifies UID/GID mappings.
 pub struct LinuxIdMapping {
     #[serde(default, rename = "hostID")]
+    #[builder(default)]
     /// HostID is the starting UID/GID on the host to be mapped to
     /// `container_id`.
     host_id: u32,
 
     #[serde(default, rename = "containerID")]
+    #[builder(default)]
     /// ContainerID is the starting UID/GID in the container.
     container_id: u32,
 
     #[serde(default)]
+    #[builder(default)]
     /// Size is the number of IDs to be mapped.
     size: u32,
 }
@@ -252,12 +245,7 @@ impl LinuxDeviceType {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxNetDevice represents a single network device to be added to the container's network namespace
 pub struct LinuxNetDevice {
     #[serde(default)]
@@ -280,17 +268,13 @@ pub struct LinuxNetDevice {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Represents a device rule for the devices specified to the device
 /// controller
 pub struct LinuxDeviceCgroup {
     #[serde(default)]
     #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
+    #[builder(default)]
     /// Allow or deny
     allow: bool,
 
@@ -354,12 +338,7 @@ impl Display for LinuxDeviceCgroup {
     Setters,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxMemory for Linux cgroup 'memory' resource management.
 pub struct LinuxMemory {
@@ -424,12 +403,7 @@ pub struct LinuxMemory {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxCPU for Linux cgroup 'cpu' resource management.
 pub struct LinuxCpu {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -494,16 +468,12 @@ pub struct LinuxCpu {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3).
 pub struct LinuxPids {
     #[serde(default)]
+    #[builder(default)]
     /// Maximum number of PIDs. Default is "no limit".
     limit: i64,
 }
@@ -512,21 +482,18 @@ pub struct LinuxPids {
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxWeightDevice struct holds a `major:minor weight` pair for
 /// weightDevice.
 pub struct LinuxWeightDevice {
     #[serde(default)]
+    #[builder(default)]
     /// Major is the device's major number.
     major: i64,
 
     #[serde(default)]
+    #[builder(default)]
     /// Minor is the device's minor number.
     minor: i64,
 
@@ -543,24 +510,22 @@ pub struct LinuxWeightDevice {
 #[derive(
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair.
 pub struct LinuxThrottleDevice {
     #[serde(default)]
+    #[builder(default)]
     /// Major is the device's major number.
     major: i64,
 
     #[serde(default)]
+    #[builder(default)]
     /// Minor is the device's minor number.
     minor: i64,
 
     #[serde(default)]
+    #[builder(default)]
     /// Rate is the IO rate limit per cgroup per device.
     rate: u64,
 }
@@ -579,12 +544,7 @@ pub struct LinuxThrottleDevice {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxBlockIO for Linux cgroup 'blkio' resource management.
 pub struct LinuxBlockIo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -644,12 +604,7 @@ pub struct LinuxBlockIo {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxHugepageLimit structure corresponds to limiting kernel hugepages.
 /// Default to reservation limits if supported. Otherwise fallback to page fault limits.
 pub struct LinuxHugepageLimit {
@@ -678,12 +633,7 @@ pub struct LinuxHugepageLimit {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxInterfacePriority for network interfaces.
 pub struct LinuxInterfacePriority {
     #[serde(default)]
@@ -721,12 +671,7 @@ impl Display for LinuxInterfacePriority {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxNetwork identification and priority configuration.
 pub struct LinuxNetwork {
     #[serde(skip_serializing_if = "Option::is_none", rename = "classID")]
@@ -755,12 +700,7 @@ pub struct LinuxNetwork {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Resource constraints for container
 pub struct LinuxResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -825,12 +765,7 @@ pub struct LinuxResources {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
 /// LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11).
 pub struct LinuxRdma {
@@ -913,12 +848,7 @@ impl TryFrom<&str> for LinuxNamespaceType {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxNamespace is the configuration for a Linux namespace.
 pub struct LinuxNamespace {
     #[serde(rename = "type")]
@@ -978,12 +908,7 @@ pub fn get_default_namespaces() -> Vec<LinuxNamespace> {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxDevice represents the mknod information for a Linux special device
 /// file.
 pub struct LinuxDevice {
@@ -1049,12 +974,7 @@ impl From<&LinuxDevice> for LinuxDeviceCgroup {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxSeccomp represents syscall restrictions.
 pub struct LinuxSeccomp {
     #[getset(get_copy = "pub", set = "pub")]
@@ -1305,12 +1225,7 @@ pub enum LinuxSeccompOperator {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxSyscall is used to match a syscall in seccomp.
 pub struct LinuxSyscall {
     #[getset(get = "pub", set = "pub")]
@@ -1336,12 +1251,7 @@ pub struct LinuxSyscall {
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// LinuxSeccompArg used for matching specific syscall arguments in seccomp.
 pub struct LinuxSeccompArg {
@@ -1403,12 +1313,7 @@ pub fn get_default_readonly_paths() -> Vec<String> {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 /// LinuxIntelRdt has container runtime resource constraints for Intel RDT CAT and MBA
 /// features and flags enabling Intel RDT CMT and MBM features.
@@ -1455,12 +1360,7 @@ pub struct LinuxIntelRdt {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxPersonality represents the Linux personality syscall input.
 pub struct LinuxPersonality {
     #[getset(get_copy = "pub", set = "pub")]
@@ -1504,11 +1404,7 @@ pub enum LinuxPersonalityDomain {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxMemoryPolicy represents input for the set_mempolicy syscall.
 pub struct LinuxMemoryPolicy {
     #[getset(get_copy = "pub", set = "pub")]
@@ -1611,12 +1507,7 @@ pub enum MemoryPolicyFlagType {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// LinuxTimeOffset specifies the offset for Time Namespace
 pub struct LinuxTimeOffset {
     /// Secs is the offset of clock (in secs) in the container

--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -1,6 +1,6 @@
 use crate::error::OciSpecError;
 use crate::runtime::LinuxIdMapping;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -8,12 +8,7 @@ use std::path::PathBuf;
 #[derive(
     Builder, Clone, CopyGetters, Debug, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Root contains information about the container's root filesystem on the
 /// host.
 pub struct Root {
@@ -53,12 +48,7 @@ impl Default for Root {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError", validate = "Self::validate")
-)]
+#[builder(on(_, into), finish_fn(vis = "", name = __build))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 /// Mount specifies a mount for a container.
 pub struct Mount {
@@ -207,19 +197,17 @@ pub fn get_default_mounts() -> Vec<Mount> {
     ]
 }
 
-impl MountBuilder {
+impl Mount {
     fn validate(&self) -> Result<(), OciSpecError> {
         let uid_specified = self
             .uid_mappings
             .as_ref()
-            .and_then(|v| v.as_ref())
             .map(|v| !v.is_empty())
             .unwrap_or(false);
 
         let gid_specified = self
             .gid_mappings
             .as_ref()
-            .and_then(|v| v.as_ref())
             .map(|v| !v.is_empty())
             .unwrap_or(false);
 
@@ -230,6 +218,15 @@ impl MountBuilder {
         }
 
         Ok(())
+    }
+}
+
+impl<S: mount_builder::IsComplete> MountBuilder<S> {
+    /// Builds the `Mount`, validating that uid/gid mappings are specified together.
+    pub fn build(self) -> Result<Mount, OciSpecError> {
+        let mount = self.__build();
+        mount.validate()?;
+        Ok(mount)
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Spec`] represents the root object from the specification.
 
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::error::{oci_error, OciSpecError, Result};
+use crate::error::{oci_error, Result};
 
 mod capability;
 mod features;
@@ -47,15 +47,11 @@ pub use zos::*;
     Builder, Clone, Debug, Deserialize, Getters, MutGetters, Setters, PartialEq, Eq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct Spec {
     #[serde(default, rename = "ociVersion")]
+    #[builder(default)]
     ///  MUST be in SemVer v2.0.0 format and specifies the version of the
     /// Open Container Initiative  Runtime Specification with which
     /// the bundle complies. The Open Container Initiative
@@ -242,11 +238,10 @@ impl Spec {
             .ok_or_else(|| oci_error("no root path provided for canonicalization"))?;
         let path = Self::canonicalize_path(bundle, root.path())?;
         self.root = Some(
-            RootBuilder::default()
+            Root::builder()
                 .path(path)
                 .readonly(root.readonly().unwrap_or(false))
-                .build()
-                .map_err(|_| oci_error("failed to set canonicalized root"))?,
+                .build(),
         );
         Ok(())
     }
@@ -305,15 +300,9 @@ mod tests {
         fs::create_dir_all(&rootfs_absolute_path).expect("failed to create the testing rootfs");
         {
             // Test the case with absolute path
-            let mut spec = SpecBuilder::default()
-                .root(
-                    RootBuilder::default()
-                        .path(rootfs_absolute_path.clone())
-                        .build()
-                        .unwrap(),
-                )
-                .build()
-                .unwrap();
+            let mut spec = Spec::builder()
+                .root(Root::builder().path(rootfs_absolute_path.clone()).build())
+                .build();
 
             spec.canonicalize_rootfs(&bundle)
                 .expect("failed to canonicalize rootfs");
@@ -325,10 +314,9 @@ mod tests {
         }
         {
             // Test the case with relative path
-            let mut spec = SpecBuilder::default()
-                .root(RootBuilder::default().path(rootfs_name).build().unwrap())
-                .build()
-                .unwrap();
+            let mut spec = Spec::builder()
+                .root(Root::builder().path(rootfs_name).build())
+                .build();
 
             spec.canonicalize_rootfs(&bundle)
                 .expect("failed to canonicalize rootfs");

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -2,7 +2,7 @@ use crate::{
     error::OciSpecError,
     runtime::{Capabilities, Capability},
 };
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -24,12 +24,7 @@ use strum_macros::{Display as StrumDisplay, EnumString};
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Process contains information to start a specific application inside the
 /// container.
 pub struct Process {
@@ -44,6 +39,7 @@ pub struct Process {
     console_size: Option<Box>,
 
     #[getset(get_mut = "pub", get = "pub", set = "pub")]
+    #[builder(default)]
     /// User specifies user information for the process.
     user: User,
 
@@ -171,21 +167,18 @@ impl Default for Process {
 #[derive(
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// Box specifies dimensions of a rectangle. Used for specifying the size of
 /// a console.
 pub struct Box {
     #[serde(default)]
+    #[builder(default)]
     /// Height is the vertical dimension of a box.
     height: u64,
 
     #[serde(default)]
+    #[builder(default)]
     /// Width is the horizontal dimension of a box.
     width: u64,
 }
@@ -256,12 +249,7 @@ pub enum PosixRlimitType {
 #[derive(
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// RLimit types and restrictions.
 pub struct PosixRlimit {
@@ -293,21 +281,18 @@ pub struct PosixRlimit {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// User id (uid) and group id (gid) tracks file permissions.
 pub struct User {
     #[serde(default)]
     #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
+    #[builder(default)]
     /// UID is the user id.
     uid: u32,
 
     #[serde(default)]
     #[getset(get_mut = "pub", get_copy = "pub", set = "pub")]
+    #[builder(default)]
     /// GID is the group id.
     gid: u32,
 
@@ -329,12 +314,7 @@ pub struct User {
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Getters, Setters, Eq, PartialEq, Serialize)]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// LinuxCapabilities specifies the list of allowed capabilities that are
 /// kept for a process. <http://man7.org/linux/man-pages/man7/capabilities.7.html>
@@ -385,20 +365,17 @@ impl Default for LinuxCapabilities {
 #[derive(
     Builder, Clone, Copy, CopyGetters, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// RLimit types and restrictions.
 pub struct LinuxIOPriority {
     #[serde(default)]
+    #[builder(default)]
     /// Class represents an I/O scheduling class.
     class: IOPriorityClass,
 
     #[serde(default)]
+    #[builder(default)]
     /// Priority for the io operation
     priority: i64,
 }
@@ -434,16 +411,12 @@ pub enum IOPriorityClass {
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Getters, Setters, Eq, PartialEq, Serialize)]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// Scheduler represents the scheduling attributes for a process. It is based on
 /// the Linux sched_setattr(2) syscall.
 pub struct Scheduler {
+    #[builder(default)]
     /// Policy represents the scheduling policy (e.g., SCHED_FIFO, SCHED_RR, SCHED_OTHER).
     policy: LinuxSchedulerPolicy,
 
@@ -548,12 +521,7 @@ impl Default for LinuxSchedulerFlag {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(validate = "Self::validate", error = "OciSpecError")
-)]
+#[builder(on(_, into), finish_fn = __build)]
 #[getset(get = "pub", set = "pub")]
 /// ExecCPUAffinity specifies CPU affinity used to execute the process.
 /// This setting is not applicable to the container's init process.
@@ -582,17 +550,26 @@ pub struct ExecCPUAffinity {
     cpu_affinity_final: Option<String>,
 }
 
-impl ExecCPUAffinityBuilder {
+impl ExecCPUAffinity {
     fn validate(&self) -> Result<(), OciSpecError> {
-        if let Some(Some(ref s)) = self.initial {
+        if let Some(ref s) = self.initial {
             validate_cpu_affinity(s).map_err(|e| OciSpecError::Other(e.to_string()))?;
         }
 
-        if let Some(Some(ref s)) = self.cpu_affinity_final {
+        if let Some(ref s) = self.cpu_affinity_final {
             validate_cpu_affinity(s).map_err(|e| OciSpecError::Other(e.to_string()))?;
         }
 
         Ok(())
+    }
+}
+
+impl<S: exec_c_p_u_affinity_builder::IsComplete> ExecCPUAffinityBuilder<S> {
+    /// Finishes building and validates the CPU affinity fields.
+    pub fn build(self) -> Result<ExecCPUAffinity, OciSpecError> {
+        let result = self.__build();
+        result.validate()?;
+        Ok(result)
     }
 }
 
@@ -719,7 +696,7 @@ mod tests {
 
     #[test]
     fn test_build_valid_input() {
-        let affinity = ExecCPUAffinityBuilder::default()
+        let affinity = ExecCPUAffinity::builder()
             .initial("0-3,7,8,9,10".to_string())
             .cpu_affinity_final("4-6,8".to_string())
             .build();
@@ -731,14 +708,14 @@ mod tests {
 
     #[test]
     fn test_build_invalid_initial() {
-        let affinity = ExecCPUAffinityBuilder::default()
+        let affinity = ExecCPUAffinity::builder()
             .initial("0-3,i".to_string())
             .cpu_affinity_final("4-6,8".to_string())
             .build();
         let err = affinity.unwrap_err();
         assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-3,i");
 
-        let affinity = ExecCPUAffinityBuilder::default()
+        let affinity = ExecCPUAffinity::builder()
             .initial("-".to_string())
             .cpu_affinity_final("4-6,8".to_string())
             .build();
@@ -748,14 +725,14 @@ mod tests {
 
     #[test]
     fn test_build_invalid_final() {
-        let affinity = ExecCPUAffinityBuilder::default()
+        let affinity = ExecCPUAffinity::builder()
             .initial("0-3,7".to_string())
             .cpu_affinity_final("0-l1".to_string())
             .build();
         let err = affinity.unwrap_err();
         assert_eq!(err.to_string(), "Invalid execCPUAffinity format: 0-l1");
 
-        let affinity = ExecCPUAffinityBuilder::default()
+        let affinity = ExecCPUAffinity::builder()
             .initial("0-3,7".to_string())
             .cpu_affinity_final(",1,2".to_string())
             .build();
@@ -765,7 +742,7 @@ mod tests {
 
     #[test]
     fn test_build_empty() {
-        let affinity = ExecCPUAffinityBuilder::default().build();
+        let affinity = ExecCPUAffinity::builder().build();
         let affinity = affinity.unwrap();
         assert!(affinity.initial.is_none());
         assert!(affinity.cpu_affinity_final.is_none());

--- a/src/runtime/solaris.rs
+++ b/src/runtime/solaris.rs
@@ -1,5 +1,4 @@
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 
@@ -7,12 +6,7 @@ use serde::{Deserialize, Serialize};
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// Solaris contains platform-specific configuration for Solaris application
 /// containers.
@@ -49,12 +43,7 @@ pub struct Solaris {
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// SolarisAnet provides the specification for automatic creation of network
 /// resources for this container.
@@ -92,12 +81,7 @@ pub struct SolarisAnet {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// SolarisCappedCPU allows users to set limit on the amount of CPU time
 /// that can be used by container.
@@ -110,12 +94,7 @@ pub struct SolarisCappedCPU {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// SolarisCappedMemory allows users to set the physical and swap caps on
 /// the memory that can be used by this container.

--- a/src/runtime/state.rs
+++ b/src/runtime/state.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
@@ -58,12 +58,7 @@ impl Display for ContainerState {
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct State {
     /// version is the version of the specification that is supported.
@@ -138,12 +133,7 @@ pub const SECCOMP_FD_NAME: &str = "seccompFd";
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct ContainerProcessState {
     /// version is the version of the specification that is supported.

--- a/src/runtime/test.rs
+++ b/src/runtime/test.rs
@@ -11,22 +11,20 @@ fn serialize_and_deserialize_spec() {
 
 #[test]
 fn test_linux_device_cgroup_to_string() {
-    let ldc = LinuxDeviceCgroupBuilder::default()
+    let ldc = LinuxDeviceCgroup::builder()
         .allow(true)
         .typ(LinuxDeviceType::B)
         .access("rwm".to_string())
-        .build()
-        .expect("build device cgroup");
+        .build();
     assert_eq!(ldc.to_string(), "b *:* rwm");
 
-    let ldc = LinuxDeviceCgroupBuilder::default()
+    let ldc = LinuxDeviceCgroup::builder()
         .allow(true)
         .typ(LinuxDeviceType::A)
         .major(1)
         .minor(9)
         .access("rwm".to_string())
-        .build()
-        .expect("build device cgroup");
+        .build();
     assert_eq!(ldc.to_string(), "a 1:9 rwm");
 }
 
@@ -87,10 +85,7 @@ fn test_linux_netdevice_lifecycle() {
 
     // Set ens6
     let mut net_devices = net_devices.clone();
-    let ens6 = LinuxNetDeviceBuilder::default()
-        .name("ens6".to_string())
-        .build()
-        .unwrap();
+    let ens6 = LinuxNetDevice::builder().name("ens6".to_string()).build();
     net_devices.insert("ens6".to_string(), ens6);
     assert_eq!(net_devices.len(), 4);
 

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -1,5 +1,4 @@
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -7,12 +6,7 @@ use std::path::PathBuf;
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// VM contains information for virtual-machine-based containers.
 pub struct VM {
@@ -34,12 +28,7 @@ pub struct VM {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// VMHypervisor contains information about the hypervisor to use for a
 /// virtual machine.
@@ -56,12 +45,7 @@ pub struct VMHypervisor {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// VMKernel contains information about the kernel to use for a virtual
 /// machine.
@@ -83,12 +67,7 @@ pub struct VMKernel {
 #[derive(
     Builder, Clone, Debug, Default, Deserialize, Getters, Setters, Eq, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// VMImage contains information about the virtual machine root image.
 pub struct VMImage {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -1,5 +1,4 @@
-use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -18,12 +17,7 @@ use std::collections::HashMap;
     Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// Windows defines the runtime configuration for Windows based containers,
 /// including Hyper-V containers.
 pub struct Windows {
@@ -79,12 +73,7 @@ pub struct Windows {
     Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// WindowsDevice represents information about a host device to be mapped
 /// into the container.
@@ -99,12 +88,7 @@ pub struct WindowsDevice {
 #[derive(
     Builder, Clone, Copy, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// Available windows resources.
 pub struct WindowsResources {
@@ -124,12 +108,7 @@ pub struct WindowsResources {
 #[derive(
     Builder, Clone, Copy, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// WindowsMemoryResources contains memory resource management settings.
 pub struct WindowsMemoryResources {
@@ -141,12 +120,7 @@ pub struct WindowsMemoryResources {
 #[derive(
     Builder, Clone, Copy, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// WindowsCPUResources contains CPU resource management settings.
 pub struct WindowsCPUResources {
@@ -168,12 +142,7 @@ pub struct WindowsCPUResources {
     Builder, Clone, Copy, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get_copy = "pub", set = "pub")]
 /// WindowsStorageResources contains storage resource management settings.
 pub struct WindowsStorageResources {
@@ -195,12 +164,7 @@ pub struct WindowsStorageResources {
     Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// WindowsHyperV contains information for configuring a container to run
 /// with Hyper-V isolation.
@@ -215,12 +179,7 @@ pub struct WindowsHyperV {
     Builder, Clone, Debug, Default, Deserialize, Eq, Getters, Setters, PartialEq, Serialize,
 )]
 #[serde(rename_all = "camelCase")]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// WindowsNetwork contains network settings for Windows containers.
 pub struct WindowsNetwork {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/runtime/zos.rs
+++ b/src/runtime/zos.rs
@@ -1,5 +1,5 @@
 use crate::error::OciSpecError;
-use derive_builder::Builder;
+use bon::Builder;
 use getset::{CopyGetters, Getters, Setters};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -18,12 +18,7 @@ use strum_macros::Display as StrumDisplay;
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 #[getset(get = "pub", set = "pub")]
 /// ZOS contains information for z/OS based containers.
 pub struct ZOS {
@@ -79,12 +74,7 @@ impl TryFrom<&str> for ZOSNamespaceType {
     PartialEq,
     Serialize,
 )]
-#[builder(
-    default,
-    pattern = "owned",
-    setter(into, strip_option),
-    build_fn(error = "OciSpecError")
-)]
+#[builder(on(_, into))]
 /// ZOSNamespace is the configuration for a z/OS namespace.
 pub struct ZOSNamespace {
     #[serde(rename = "type")]


### PR DESCRIPTION
derive_builder is very popular, but a key selling point of bon is its usage of typestate to ensure that all required fields are provided.

Using this crate before this change required pretty pervasive usage of `unwrap()` unnecessarily (or `?` in places that otherwise wouldn't need a `Result`), now with bon it doesn't.

Since this crate is regularly bumping semver anyways, let's make doing so valuable.

Closes: #242

Assisted-by: OpenCode (Claude claude-opus-4-6)

/kind api-change

```release-note
The project has been ported to bon instead of derive_builder, which ensures objects have the required properties at build time, removing the need for unnecessary `unwrap()`.
```
