### PR TITLE
Update LinuxIntelRdt for v1.3.0 (Breaking Changes)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,11 @@ fn to_string<T: Serialize>(item: &T, pretty: bool) -> Result<String> {
         false => serde_json::to_string(item)?,
     })
 }
+
+// A generic helper for any Option containing a collection (Vec, HashMap, String ...etc).
+fn is_none_or_empty<C>(opt: &Option<C>) -> bool
+where
+    for<'a> &'a C: IntoIterator,
+{
+    opt.as_ref().is_none_or(|c| c.into_iter().next().is_none())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ fn to_string<T: Serialize>(item: &T, pretty: bool) -> Result<String> {
     })
 }
 
-// A generic helper for any Option containing a collection (Vec, HashMap, String ...etc).
+// A generic helper for any Option containing a collection whose reference implements `IntoIterator` (e.g., Vec, HashMap).
 fn is_none_or_empty<C>(opt: &Option<C>) -> bool
 where
     for<'a> &'a C: IntoIterator,

--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -277,6 +277,17 @@ pub struct IntelRdt {
     /// "enabled" field represents whether Intel RDT support is compiled in.
     /// Unrelated to whether the host supports Intel RDT or not.
     enabled: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Schemata is true if the "linux.intelRdt.schemata" field of the
+    /// spec is implemented.
+    schemata: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Monitoring is true if the "linux.intelRdt.enableMonitoring" field of the
+    /// spec is implemented.
+    /// Nil value means "unknown", not "false".
+    monitoring: Option<bool>,
 }
 
 /// MemoryPolicy represents the "memoryPolicy" field.
@@ -852,7 +863,9 @@ mod tests {
         assert_eq!(
             linux.intel_rdt.as_ref().unwrap(),
             &IntelRdt {
-                enabled: Some(true)
+                enabled: Some(true),
+                schemata: None,
+                monitoring: None,
             }
         );
 

--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -287,7 +287,7 @@ pub struct IntelRdt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Monitoring is true if the "linux.intelRdt.enableMonitoring" field of the
     /// spec is implemented.
-    /// Nil value means "unknown", not "false".
+    /// None value means "unknown", not "false".
     monitoring: Option<bool>,
 }
 

--- a/src/runtime/features.rs
+++ b/src/runtime/features.rs
@@ -274,6 +274,7 @@ pub struct Selinux {
 )]
 #[getset(get_mut = "pub", get = "pub", set = "pub")]
 pub struct IntelRdt {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// "enabled" field represents whether Intel RDT support is compiled in.
     /// Unrelated to whether the host supports Intel RDT or not.
     enabled: Option<bool>,

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1445,27 +1445,31 @@ pub struct LinuxIntelRdt {
     clos_id: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Schemata specifies the complete schemata to be written as is to the
+    /// schemata file in resctrl fs. Each element represents a single line in the schemata file.
+    /// NOTE: This will overwrite schemas specified in the L3CacheSchema and/or
+    /// MemBwSchema fields.
+    schemata: Option<Vec<String>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The schema for L3 cache id and capacity bitmask (CBM).
-    /// Format: "L3:&lt;cache_id0&gt;=&lt;cbm0&gt;;&lt;cache_id1&gt;=&lt;cbm1&gt;;..."
+    /// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+    /// NOTE: Should not be specified if Schemata is non-empty.
     l3_cache_schema: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The schema of memory bandwidth per L3 cache id.
-    /// Format: "MB:&lt;cache_id0&gt;=bandwidth0;&lt;cache_id1&gt;=bandwidth1;..."
+    /// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
     /// The unit of memory bandwidth is specified in "percentages" by
     /// default, and in "MBps" if MBA Software Controller is
     /// enabled.
+    /// NOTE: Should not be specified if Schemata is non-empty.
     mem_bw_schema: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    /// EnableCMT is the flag to indicate if the Intel RDT CMT is enabled. CMT (Cache Monitoring Technology) supports monitoring of
-    /// the last-level cache (LLC) occupancy for the container.
-    enable_cmt: Option<bool>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    /// EnableMBM is the flag to indicate if the Intel RDT MBM is enabled. MBM (Memory Bandwidth Monitoring) supports monitoring of
-    /// total and local memory bandwidth for the container.
-    enable_mbm: Option<bool>,
+    /// EnableMonitoring enables resctrl monitoring for the container. This will
+    /// create a dedicated resctrl monitoring group for the container.
+    enable_monitoring: Option<bool>,
 }
 
 #[derive(

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1453,13 +1453,13 @@ pub struct LinuxIntelRdt {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The schema for L3 cache id and capacity bitmask (CBM).
-    /// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+    /// Format: "L3:&lt;cache_id0&gt;=&lt;cbm0&gt;;&lt;cache_id1&gt;=&lt;cbm1&gt;;..."
     /// NOTE: Should not be specified if Schemata is non-empty.
     l3_cache_schema: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// The schema of memory bandwidth per L3 cache id.
-    /// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+    /// Format: "MB:&lt;cache_id0&gt;=bandwidth0;&lt;cache_id1&gt;=bandwidth1;..."
     /// The unit of memory bandwidth is specified in "percentages" by
     /// default, and in "MBps" if MBA Software Controller is
     /// enabled.

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1466,6 +1466,32 @@ pub struct LinuxIntelRdt {
     /// NOTE: Should not be specified if Schemata is non-empty.
     mem_bw_schema: Option<String>,
 
+    #[deprecated(
+        since = "0.10.0",
+        note = "enable_cmt is deprecated in runtime-spec v1.3.0. Use enable_monitoring instead."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// EnableCMT is the flag to indicate if the Intel RDT CMT is enabled. CMT (Cache Monitoring Technology) supports monitoring of
+    /// the last-level cache (LLC) occupancy for the container.
+    ///
+    /// # Deprecated
+    /// This field is deprecated in runtime-spec v1.3.0.
+    /// Use `enable_monitoring` instead.
+    enable_cmt: Option<bool>,
+
+    #[deprecated(
+        since = "0.10.0",
+        note = "enable_mbm is deprecated in runtime-spec v1.3.0. Use enable_monitoring instead."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// EnableMBM is the flag to indicate if the Intel RDT MBM is enabled. MBM (Memory Bandwidth Monitoring) supports monitoring of
+    /// total and local memory bandwidth for the container.
+    ///
+    /// # Deprecated
+    /// This field is deprecated in runtime-spec v1.3.0.
+    /// Use `enable_monitoring` instead.
+    enable_mbm: Option<bool>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// EnableMonitoring enables resctrl monitoring for the container. This will
     /// create a dedicated resctrl monitoring group for the container.

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1,4 +1,5 @@
 use crate::error::{oci_error, OciSpecError};
+use crate::is_none_or_empty;
 
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, MutGetters, Setters};
@@ -1444,7 +1445,7 @@ pub struct LinuxIntelRdt {
     /// The identity for RDT Class of Service.
     clos_id: Option<String>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "is_none_or_empty")]
     /// Schemata specifies the complete schemata to be written as is to the
     /// schemata file in resctrl fs. Each element represents a single line in the schemata file.
     /// NOTE: This will overwrite schemas specified in the L3CacheSchema and/or


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind api-change
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR updates the `LinuxIntelRdt` struct and `IntelRdt` features struct to align with OCI runtime-spec v1.3.0. 

Specifically, it:
* Introduces the `schemata` field (an array of strings) and `enable_monitoring` field to `LinuxIntelRdt`.
* Removes the deprecated `enable_cmt` and `enable_mbm` fields from `LinuxIntelRdt`.
* Adds the `schemata` and `monitoring` boolean flags to the `IntelRdt` features struct.
* Updates the unit tests to pass with the new schema constraints.

This is a required prerequisite for `youki` to be able to fully support OCI runtime-spec v1.3.0 changes regarding Intel RDT monitoring and schemata group creations.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #314
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

This is a breaking API change for anyone using `LinuxIntelRdt::enable_cmt` or `LinuxIntelRdt::enable_mbm`. 

We have fully removed these legacy fields instead of merely deprecating them to mirror the v1.3.0 OCI runtime spec changes and ensure consumers properly migrate to the new `enable_monitoring` and `schemata` definitions.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
ACTION REQUIRED: Updated `LinuxIntelRdt` to align with OCI runtime-spec v1.3.0. 
The `enable_cmt` and `enable_mbm` fields have been removed and replaced with `enable_monitoring` and a `schemata` array. 
Consumers mapping these specs directly will need to update their code.
```
