### PR TITLE
WIP:bon typestate pattern builder for runtime spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ getset = "0.1.3"
 strum = "0.27.0"
 strum_macros = "0.27.0"
 regex = "1"
+bon = "3.9.3"
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -199,6 +199,19 @@ pub struct LinuxIdMapping {
     size: u32,
 }
 
+#[bon::bon]
+impl LinuxIdMapping {
+    #[builder(finish_fn(name=build_idmapping))]
+    /// Linux Id Mapping builder with bon
+    pub fn idmapping_builder(host_id: u32, container_id: u32, size: u32) -> Self {
+        LinuxIdMapping {
+            host_id,
+            container_id,
+            size,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, EnumString)]
 #[strum(serialize_all = "lowercase")]
 #[serde(rename_all = "lowercase")]

--- a/src/runtime/miscellaneous.rs
+++ b/src/runtime/miscellaneous.rs
@@ -40,6 +40,21 @@ impl Default for Root {
     }
 }
 
+#[bon::bon]
+impl Root {
+    #[builder(finish_fn(name=build_root))]
+    /// Root Builder using bon
+    pub fn root_builder<P>(path: P, readonly: Option<bool>) -> Self
+    where
+        P: Into<std::path::PathBuf>,
+    {
+        Self {
+            path: path.into(),
+            readonly,
+        }
+    }
+}
+
 #[derive(
     Builder,
     Clone,
@@ -109,6 +124,167 @@ pub struct Mount {
     ///
     /// See: <https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-mounts>
     gid_mappings: Option<Vec<LinuxIdMapping>>,
+}
+
+#[bon::bon]
+impl Mount {
+    #[builder]
+    /// Mount Builder using bon
+    pub fn mount_builder(
+        #[builder(field)] options: Option<Vec<String>>,
+        #[builder(field)] uid_mappings: Option<Vec<LinuxIdMapping>>,
+        #[builder(field)] gid_mappings: Option<Vec<LinuxIdMapping>>,
+        #[builder(into)] destination: PathBuf,
+        #[builder(into)] typ: Option<String>,
+        #[builder(into)] source: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            destination,
+            typ,
+            source,
+            options,
+            uid_mappings,
+            gid_mappings,
+        }
+    }
+}
+
+#[bon::bon]
+impl MountMountBuilderBuilder {
+    #[builder(finish_fn(name = build_options))]
+    /// Mount Options builder using bon
+    pub fn options_builder(mut self, #[builder(field)] options: Vec<String>) -> Self {
+        self.options = Some(options);
+        self
+    }
+
+    #[builder(finish_fn(name = build_uid_mappings))]
+    /// Mount UID Mappings builder using bon
+    pub fn uid_mappings_builder(
+        mut self,
+        #[builder(field)] uid_mappings: Vec<LinuxIdMapping>,
+    ) -> Self {
+        self.uid_mappings = Some(uid_mappings);
+        self
+    }
+
+    #[builder(finish_fn(name = build_gid_mappings))]
+    /// Mount GID Mappings builder using bon
+    pub fn gid_mappings_builder(
+        mut self,
+        #[builder(field)] gid_mappings: Vec<LinuxIdMapping>,
+    ) -> Self {
+        self.gid_mappings = Some(gid_mappings);
+        self
+    }
+
+    /// Set options directly with no builder
+    pub fn options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+        self.options = Some(options.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Set uid mappings directly with no builder
+    pub fn uid_mappings(
+        mut self,
+        uid_mappings: impl IntoIterator<Item: Into<LinuxIdMapping>>,
+    ) -> Self {
+        self.uid_mappings = Some(uid_mappings.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Set gid mappings directly with no builder
+    pub fn gid_mappings(
+        mut self,
+        gid_mappings: impl IntoIterator<Item: Into<LinuxIdMapping>>,
+    ) -> Self {
+        self.gid_mappings = Some(gid_mappings.into_iter().map(Into::into).collect());
+        self
+    }
+}
+
+impl MountMountBuilderBuilderOptionsBuilderBuilder {
+    /// Mount builder fn to add just one option to the vec of options
+    pub fn add_option(mut self, option: impl Into<String>) -> Self {
+        self.options.push(option.into());
+        self
+    }
+
+    /// Mount builder fn to add vec of options together
+    pub fn add_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+        self.options.extend(options.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl MountMountBuilderBuilderUidMappingsBuilderBuilder {
+    /// UidMappingsBuilder with direct host_id container_id and size values
+    pub fn with_hostid_containerid_and_size(
+        mut self,
+        host_id: u32,
+        container_id: u32,
+        size: u32,
+    ) -> Self {
+        self.uid_mappings.push(
+            LinuxIdMapping::idmapping_builder()
+                .host_id(host_id)
+                .container_id(container_id)
+                .size(size)
+                .build_idmapping(),
+        );
+        self
+    }
+
+    /// UidMappingBuilder to add just one option to vec of uid mappings
+    pub fn add_id_mapping(mut self, id_mapping: impl Into<LinuxIdMapping>) -> Self {
+        self.uid_mappings.push(id_mapping.into());
+        self
+    }
+
+    /// UidMappingBuilder to add vec of uid mappings together
+    pub fn add_id_mappings(
+        mut self,
+        id_mappings: impl IntoIterator<Item: Into<LinuxIdMapping>>,
+    ) -> Self {
+        self.uid_mappings
+            .extend(id_mappings.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl MountMountBuilderBuilderGidMappingsBuilderBuilder {
+    /// GidMappingsBuilder with direct host_id container_id and size values
+    pub fn with_hostid_containerid_and_size(
+        mut self,
+        host_id: u32,
+        container_id: u32,
+        size: u32,
+    ) -> Self {
+        self.gid_mappings.push(
+            LinuxIdMapping::idmapping_builder()
+                .host_id(host_id)
+                .container_id(container_id)
+                .size(size)
+                .build_idmapping(),
+        );
+        self
+    }
+
+    /// GidMappingBuilder to add just one option to vec of uid mappings
+    pub fn add_id_mapping(mut self, id_mapping: impl Into<LinuxIdMapping>) -> Self {
+        self.gid_mappings.push(id_mapping.into());
+        self
+    }
+
+    /// GidMappingBuilder to add vec of gid mappings together
+    pub fn add_id_mappings(
+        mut self,
+        id_mappings: impl IntoIterator<Item: Into<LinuxIdMapping>>,
+    ) -> Self {
+        self.gid_mappings
+            .extend(id_mappings.into_iter().map(Into::into));
+        self
+    }
 }
 
 /// utility function to generate default config for mounts.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -212,6 +212,87 @@ impl Default for Spec {
     }
 }
 
+#[bon::bon]
+impl Spec {
+    #[builder(finish_fn(name = build_spec))]
+    /// Spec Builder using bon
+    pub fn spec_builder(
+        #[builder(field)] root: Option<Root>,
+        #[builder(field)] mounts: Option<Vec<crate::runtime::Mount>>,
+        process: Option<crate::runtime::Process>,
+        hooks: Option<crate::runtime::Hooks>,
+        annotations: Option<HashMap<String, String>>,
+        linux: Option<crate::runtime::Linux>,
+        solaris: Option<crate::runtime::Solaris>,
+        windows: Option<crate::runtime::Windows>,
+        vm: Option<crate::runtime::VM>,
+        zos: Option<crate::runtime::ZOS>,
+        #[builder(into)] version: String,
+        #[builder(into)] hostname: Option<String>,
+        #[builder(into)] domainname: Option<String>,
+    ) -> Self {
+        Self {
+            version,
+            root,
+            mounts,
+            process,
+            hostname,
+            domainname,
+            hooks,
+            annotations,
+            linux,
+            solaris,
+            windows,
+            vm,
+            zos,
+            ..Default::default()
+        }
+    }
+}
+
+#[bon::bon]
+impl<S: spec_spec_builder_builder::State> SpecSpecBuilderBuilder<S> {
+    #[builder(finish_fn(name = build_root))]
+    /// Bon Root builder for spec
+    pub fn root_builder(
+        mut self,
+        path: impl Into<std::path::PathBuf>,
+        readonly: Option<bool>,
+    ) -> Self {
+        self.root = Some(
+            Root::root_builder()
+                .path(path)
+                .maybe_readonly(readonly)
+                .build_root(),
+        );
+        self
+    }
+
+    /// Directly set root with Into<Root> value
+    pub fn root(mut self, root: impl Into<Root>) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    /// Set non-readonly root with given root folder path
+    pub fn with_root_folder_path(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.root = Some(Root::root_builder().path(path).build_root());
+        self
+    }
+
+    /// Set readonly root path with given path
+    pub fn with_readonly_root_folder_path(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.root = Some(Root::root_builder().path(path).readonly(true).build_root());
+        self
+    }
+
+    /// Set Mounts with any value that implements the Into trait
+    pub fn mounts(mut self, mounts: impl IntoIterator<Item: Into<Mount>>) -> Self {
+        self.mounts = Some(mounts.into_iter().map(Into::into).collect());
+        self
+    }
+}
+
 impl Spec {
     /// Load a new `Spec` from the provided JSON file `path`.
     /// # Errors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/oci-spec-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

This is a new additional feature PR to build typestate pattern builder for runtime spec and other spec. I am working on cri server that implements cri protocol to communicate with kubernetes. The current builder api to build runtime spec is a pain and doesn't help maintain clean code while building the struct. I am writing a new builder pattern fn using bon so that I can use oci spec for building config.json in my project.
<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->


#### What this PR does / why we need it:
We need this change for more sane builder pattern to build runtime spec using TypeState Builder Pattern in Rust.
#### Which issue(s) this PR fixes:
Fixes https://github.com/youki-dev/oci-spec-rs/issues/242
Fixes #340 (if approved to remove getset)
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Hey, I use this crate in my projects and I just want to contribute to this crate so that it is more useful for developers who use this crate like me. I am building a typestate builder pattern for runtime spec because I need it for my usecase. It is still a work in progress and I would be grateful for your feedback and suggestion. This PR is still work in progress and any feedback on how to name apis and anyother thing will be greatly appreciated.

#### Does this PR introduce a user-facing change?
Yes. It is additive and it does not introduce any breaking changes.
getset has a rustsec vulnerability with proc_macro2 crate. If approved we can remove the getset crate in future releases otherwise we can keep the bon builder as additive feature.
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
